### PR TITLE
Fix pysmt install

### DIFF
--- a/penaltymodel_maxgap/penaltymodel_maxgap/package_info.py
+++ b/penaltymodel_maxgap/penaltymodel_maxgap/package_info.py
@@ -1,4 +1,4 @@
-__version__ = '0.3.0'
+__version__ = '0.3.1'
 __author__ = 'D-Wave Systems Inc.'
 __authoremail__ = 'acondello@dwavesys.com'
 __description__ = 'Generates penalty models using smt solvers.'

--- a/penaltymodel_maxgap/setup.py
+++ b/penaltymodel_maxgap/setup.py
@@ -46,7 +46,7 @@ class PysmtSolverInstall(install):
         shutil.rmtree(install_dir)
 
 
-setup_requires = ['pysmt>=0.7.0,<0.8.0']
+setup_requires = ['pysmt==0.7.0']
 install_requires = ['six>=1.11.0,<2.0.0',
                     'dwave_networkx>=0.6.0,<0.7.0',
                     'pysmt>=0.7.0,<0.8.0',


### PR DESCRIPTION
When pysmt bumped version to 0.7.5 it broke the way that z3 was installed. For now we are reverting to use 0.7.0.