### PR TITLE
Fix CI integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
           name: integration tests
           command: |
             . env/bin/activate
-            python -m unittest discover
+            python -m unittest discover tests/
 
       - run:
           name: doctest


### PR DESCRIPTION
Previously the unittests were re-run by circle-ci when it was supposed to only run the integration tests.