### PR TITLE
Feature 70/use min gap as a constraint in penaltymodels

### DIFF
--- a/penaltymodel_cache/.idea/vcs.xml
+++ b/penaltymodel_cache/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/penaltymodel_cache/penaltymodel/cache/database_manager.py
+++ b/penaltymodel_cache/penaltymodel/cache/database_manager.py
@@ -479,12 +479,9 @@ def insert_penalty_model(cur, penalty_model):
     insert_feasible_configurations(cur, penalty_model.feasible_configurations, encoded_data)
     insert_ising_model(cur, nodelist, edgelist, linear, quadratic, offset, encoded_data)
 
-    if 'decision_variables' not in encoded_data:
-        encoded_data['decision_variables'] = json.dumps(penalty_model.decision_variables, separators=(',', ':'))
-    if 'classical_gap' not in encoded_data:
-        encoded_data['classical_gap'] = penalty_model.classical_gap
-    if 'ground_energy' not in encoded_data:
-        encoded_data['ground_energy'] = penalty_model.ground_energy
+    encoded_data['decision_variables'] = json.dumps(penalty_model.decision_variables, separators=(',', ':'))
+    encoded_data['classical_gap'] = penalty_model.classical_gap
+    encoded_data['ground_energy'] = penalty_model.ground_energy
 
     insert = \
         """

--- a/penaltymodel_cache/setup.py
+++ b/penaltymodel_cache/setup.py
@@ -11,7 +11,7 @@ if _PY2:
 else:
     exec(open("./penaltymodel/cache/package_info.py").read())
 
-install_requires = ['penaltymodel>=0.15.0,<0.17.0',
+install_requires = ['penaltymodel>=0.16.0,<0.17.0',
                     'six>=1.11.0,<2.0.0',
                     'homebase>=1.0.0,<2.0.0',
                     'dimod>=0.6.0,<0.9.0'

--- a/penaltymodel_cache/setup.py
+++ b/penaltymodel_cache/setup.py
@@ -11,7 +11,7 @@ if _PY2:
 else:
     exec(open("./penaltymodel/cache/package_info.py").read())
 
-install_requires = ['penaltymodel>=0.15.0,<0.16.0',
+install_requires = ['penaltymodel>=0.15.0,<0.17.0',
                     'six>=1.11.0,<2.0.0',
                     'homebase>=1.0.0,<2.0.0',
                     'dimod>=0.6.0,<0.9.0'

--- a/penaltymodel_cache/tests/test_database_manager.py
+++ b/penaltymodel_cache/tests/test_database_manager.py
@@ -157,3 +157,58 @@ class TestDatabaseManager(unittest.TestCase):
             self.assertEqual(len(pms), 1)
             widget_, = pms
             self.assertEqual(widget_, widget)
+
+    def test_penalty_model_classical_gap_insert_retrieve(self):
+        """Verify that classical gap constraint searches work in the database.
+        """
+        conn = self.clean_connection
+
+        # Set up specifications for widget
+        decision_variables = ['a', 'b', 'c']
+        graph = nx.path_graph(decision_variables)
+        and_gate_configurations = {(-1, -1, -1): 0,
+                                   (-1, +1, -1): 0,
+                                   (+1, -1, -1): 0,
+                                   (+1, +1, +1): 0}
+        linear = {v: 0 for v in graph}
+        quadratic = {edge: -1 for edge in graph.edges}
+        model = dimod.BinaryQuadraticModel(linear, quadratic, 0.0, vartype=dimod.SPIN)
+
+        spec = pm.Specification(graph, decision_variables, and_gate_configurations, dimod.SPIN)
+        widget = pm.PenaltyModel.from_specification(spec, model, 2., -2)
+
+        # Insert widget into database
+        with conn as cur:
+            pmc.insert_penalty_model(cur, widget)
+
+        # Test specifications with varying classical gap sizes
+        max_gap = 2
+        spec_same_gap = pm.Specification(graph, decision_variables, and_gate_configurations,
+                                         dimod.SPIN, min_classical_gap=max_gap)
+        spec_smaller_gap = pm.Specification(graph, decision_variables, and_gate_configurations,
+                                            dimod.SPIN, min_classical_gap=max_gap-1)
+        spec_larger_gap = pm.Specification(graph, decision_variables, and_gate_configurations,
+                                           dimod.SPIN, min_classical_gap=max_gap+1)
+
+        # Find in database
+        with conn as cur:
+            # Search database for penalty models matching specifications
+            pms_same_gap = list(pmc.iter_penalty_model_from_specification(cur, spec_same_gap))
+            pms_smaller_gap = list(pmc.iter_penalty_model_from_specification(cur, spec_smaller_gap))
+            pms_larger_gap = list(pmc.iter_penalty_model_from_specification(cur, spec_larger_gap))
+
+            # Test specification that uses the max classical gap as its min_classical_gap
+            self.assertEqual(len(pms_same_gap), 1, 'Using max gap should return a penalty model.')
+            widget_same_gap_, = pms_same_gap
+            self.assertEqual(widget_same_gap_, widget)
+
+            # Specification uses a gap that is smaller than the expected max classical gap
+            self.assertEqual(len(pms_smaller_gap), 1, 'Using a gap that is less than the max gap'
+                                                      ' should return a penalty model.')
+            widget_smaller_gap_, = pms_smaller_gap
+            self.assertEqual(widget_smaller_gap_, widget)
+
+            # Specification uses a gap that is larger than the expected max classical gap
+            # Note: classical gap constraint shouldn't be satisfied in this case
+            self.assertEqual(len(pms_larger_gap), 0, 'Using a gap that exceeds the max gap should'
+                                                     ' not return a penalty model.')

--- a/penaltymodel_core/penaltymodel/core/classes/penaltymodel.py
+++ b/penaltymodel_core/penaltymodel/core/classes/penaltymodel.py
@@ -5,9 +5,8 @@ PenaltyModel
 from __future__ import absolute_import
 
 from numbers import Number
-import itertools
 
-from six import itervalues, iteritems
+from six import iteritems
 import networkx as nx
 
 from dimod import BinaryQuadraticModel, Vartype

--- a/penaltymodel_core/penaltymodel/core/classes/penaltymodel.py
+++ b/penaltymodel_core/penaltymodel/core/classes/penaltymodel.py
@@ -135,6 +135,7 @@ class PenaltyModel(Specification):
 
         Specification.__init__(self, graph, decision_variables, feasible_configurations,
                                vartype=vartype,
+                               min_classical_gap=classical_gap,
                                ising_linear_ranges=ising_linear_ranges,
                                ising_quadratic_ranges=ising_quadratic_ranges)
 

--- a/penaltymodel_core/penaltymodel/core/classes/specification.py
+++ b/penaltymodel_core/penaltymodel/core/classes/specification.py
@@ -120,7 +120,8 @@ class Specification(object):
 
     """
     @dimod.decorators.vartype_argument('vartype')
-    def __init__(self, graph, decision_variables, feasible_configurations, vartype, min_classical_gap,
+    def __init__(self, graph, decision_variables, feasible_configurations, vartype,
+                 min_classical_gap=2.0,
                  ising_linear_ranges=None,
                  ising_quadratic_ranges=None):
 

--- a/penaltymodel_core/penaltymodel/core/classes/specification.py
+++ b/penaltymodel_core/penaltymodel/core/classes/specification.py
@@ -121,9 +121,7 @@ class Specification(object):
     """
     @dimod.decorators.vartype_argument('vartype')
     def __init__(self, graph, decision_variables, feasible_configurations, vartype,
-                 min_classical_gap=2.0,
-                 ising_linear_ranges=None,
-                 ising_quadratic_ranges=None):
+                 ising_linear_ranges=None, ising_quadratic_ranges=None, min_classical_gap=2):
 
         #
         # graph

--- a/penaltymodel_core/penaltymodel/core/classes/specification.py
+++ b/penaltymodel_core/penaltymodel/core/classes/specification.py
@@ -10,7 +10,6 @@ import itertools
 import networkx as nx
 
 import dimod
-from dimod import BinaryQuadraticModel
 from six import itervalues, iteritems, iterkeys
 
 

--- a/penaltymodel_core/penaltymodel/core/classes/specification.py
+++ b/penaltymodel_core/penaltymodel/core/classes/specification.py
@@ -120,7 +120,7 @@ class Specification(object):
 
     """
     @dimod.decorators.vartype_argument('vartype')
-    def __init__(self, graph, decision_variables, feasible_configurations, vartype,
+    def __init__(self, graph, decision_variables, feasible_configurations, vartype, min_classical_gap,
                  ising_linear_ranges=None,
                  ising_quadratic_ranges=None):
 
@@ -169,6 +169,13 @@ class Specification(object):
         #
         self.ising_linear_ranges = self._check_ising_linear_ranges(ising_linear_ranges, graph)
         self.ising_quadratic_ranges = self._check_ising_quadratic_ranges(ising_quadratic_ranges, graph)
+
+        #
+        # min_classical_gap
+        #
+        if min_classical_gap <= 0:
+            raise ValueError("min_classical_gap must be a positive number")
+        self.min_classical_gap = min_classical_gap
 
         #
         # vartype

--- a/penaltymodel_core/penaltymodel/core/classes/specification.py
+++ b/penaltymodel_core/penaltymodel/core/classes/specification.py
@@ -117,8 +117,9 @@ class Specification(object):
             u and v are variables in the desired penalty model and u, v have an
             interaction - there is an edge between nodes u, v in `graph`.
 
-        min_classical_gap (float): The minimum energy gap between the highest feasible state and
-            the lowest infeasible state. Default value is 2.
+        min_classical_gap (float):
+            This is a threshold value for the classical gap. It describes the minimum energy gap
+            between the highest feasible state and the lowest infeasible state. Default value is 2.
 
     """
     @dimod.decorators.vartype_argument('vartype')

--- a/penaltymodel_core/penaltymodel/core/classes/specification.py
+++ b/penaltymodel_core/penaltymodel/core/classes/specification.py
@@ -117,6 +117,9 @@ class Specification(object):
             u and v are variables in the desired penalty model and u, v have an
             interaction - there is an edge between nodes u, v in `graph`.
 
+        min_classical_gap (float): The minimum energy gap between the highest feasible state and
+            the lowest infeasible state. Default value is 2.
+
     """
     @dimod.decorators.vartype_argument('vartype')
     def __init__(self, graph, decision_variables, feasible_configurations, vartype,

--- a/penaltymodel_core/penaltymodel/core/package_info.py
+++ b/penaltymodel_core/penaltymodel/core/package_info.py
@@ -1,4 +1,4 @@
-__version__ = '0.15.4'
+__version__ = '0.15.5'
 __author__ = 'D-Wave Systems Inc.'
 __authoremail__ = 'acondello@dwavesys.com'
 __description__ = 'Utilities and interfaces for using penalty models.'

--- a/penaltymodel_core/penaltymodel/core/package_info.py
+++ b/penaltymodel_core/penaltymodel/core/package_info.py
@@ -1,4 +1,4 @@
-__version__ = '0.15.5'
+__version__ = '0.16.0'
 __author__ = 'D-Wave Systems Inc.'
 __authoremail__ = 'acondello@dwavesys.com'
 __description__ = 'Utilities and interfaces for using penalty models.'

--- a/penaltymodel_core/setup.py
+++ b/penaltymodel_core/setup.py
@@ -15,8 +15,9 @@ install_requires = ['dimod>=0.6.3,<0.9.0',
                     ]
 
 extras_require = {'all': ['penaltymodel_cache>=0.3.0,<0.4.0',
-                          'penaltymodel_maxgap>=0.4.0,<0.5.0',
-                          "penaltymodel_mip>=0.1.0,<0.2.0; platform_machine!='x86' and python_version!='3.4'"
+                          'penaltymodel_lp>=0.0.0,<0.1.0',
+                          'penaltymodel_maxgap>=0.5.0,<0.6.0',
+                          "penaltymodel_mip>=0.2.0,<0.3.0; platform_machine!='x86' and python_version!='3.4'"
                           ]
                   }
 

--- a/penaltymodel_lp/penaltymodel/lp/generation.py
+++ b/penaltymodel_lp/penaltymodel/lp/generation.py
@@ -73,11 +73,8 @@ def _get_lp_matrix(spin_states, nodes, edges, offset_weight, gap_weight):
 #TODO: check table is not empty (perhaps this check should be in bqm.stitch or as a common
 # penaltymodel check)
 #TODO: Check if len(table.keys()[0]) == len(decision_variables)
-
-#TODO: Adding min_gap into code
-#TODO: Checking min_gap < max_gap (occurs at bqm.stitch or penaltymodel?)
 def generate_bqm(graph, table, decision_variables,
-                 min_classical_gap=2, linear_energy_ranges=None, quadratic_energy_ranges=None):
+                 linear_energy_ranges=None, quadratic_energy_ranges=None, min_classical_gap=2):
 
     # Check for auxiliary variables in the graph
     if len(graph) != len(decision_variables):

--- a/penaltymodel_lp/penaltymodel/lp/generation.py
+++ b/penaltymodel_lp/penaltymodel/lp/generation.py
@@ -72,7 +72,6 @@ def _get_lp_matrix(spin_states, nodes, edges, offset_weight, gap_weight):
 
 #TODO: check table is not empty (perhaps this check should be in bqm.stitch or as a common
 # penaltymodel check)
-#TODO: Check if len(table.keys()[0]) == len(decision_variables)
 def generate_bqm(graph, table, decision_variables,
                  linear_energy_ranges=None, quadratic_energy_ranges=None, min_classical_gap=2):
     """
@@ -131,7 +130,6 @@ def generate_bqm(graph, table, decision_variables,
         unnoted_bound = np.zeros((n_unnoted, 1))
 
     # Bounds
-    # Note: max_gap's max(..or..) is to support python2.7. TODO: ideally, use max([..], default)
     linear_range = (MIN_LINEAR_BIAS, MAX_LINEAR_BIAS)
     quadratic_range = (MIN_QUADRATIC_BIAS, MAX_QUADRATIC_BIAS)
 
@@ -142,7 +140,7 @@ def generate_bqm(graph, table, decision_variables,
     #   hence that 2 * sum(largest_biases)
     max_gap = 2 * sum(max(abs(lbound), abs(ubound)) for lbound, ubound in bounds)
     bounds.append((None, None))     # Bound for offset
-    bounds.append((min_classical_gap, max_gap))     # Bound for gap. TODO: bound with min_gap as well
+    bounds.append((min_classical_gap, max_gap))     # Bound for gap.
 
     # Cost function
     cost_weights = np.zeros((1, m_linear + m_quadratic + 2))

--- a/penaltymodel_lp/penaltymodel/lp/generation.py
+++ b/penaltymodel_lp/penaltymodel/lp/generation.py
@@ -77,7 +77,7 @@ def _get_lp_matrix(spin_states, nodes, edges, offset_weight, gap_weight):
 #TODO: Adding min_gap into code
 #TODO: Checking min_gap < max_gap (occurs at bqm.stitch or penaltymodel?)
 def generate_bqm(graph, table, decision_variables,
-                 linear_energy_ranges=None, quadratic_energy_ranges=None):
+                 min_classical_gap=2, linear_energy_ranges=None, quadratic_energy_ranges=None):
 
     # Check for auxiliary variables in the graph
     if len(graph) != len(decision_variables):
@@ -133,7 +133,7 @@ def generate_bqm(graph, table, decision_variables,
     #   hence that 2 * sum(largest_biases)
     max_gap = 2 * sum(max(abs(lbound), abs(ubound)) for lbound, ubound in bounds)
     bounds.append((None, None))     # Bound for offset
-    bounds.append((0, max_gap))     # Bound for gap. TODO: bound with min_gap as well
+    bounds.append((min_classical_gap, max_gap))     # Bound for gap. TODO: bound with min_gap as well
 
     # Cost function
     cost_weights = np.zeros((1, m_linear + m_quadratic + 2))

--- a/penaltymodel_lp/penaltymodel/lp/generation.py
+++ b/penaltymodel_lp/penaltymodel/lp/generation.py
@@ -75,7 +75,19 @@ def _get_lp_matrix(spin_states, nodes, edges, offset_weight, gap_weight):
 #TODO: Check if len(table.keys()[0]) == len(decision_variables)
 def generate_bqm(graph, table, decision_variables,
                  linear_energy_ranges=None, quadratic_energy_ranges=None, min_classical_gap=2):
-
+    """
+    Args:
+        graph: A networkx.Graph
+        table: An iterable of valid spin configurations. Each configuration is a tuple of
+            variable assignments ordered by `decision`.
+        decision_variables: An ordered iterable of the variables in the binary quadratic model.
+        linear_energy_ranges: Dictionary of the form {v: (min, max), ...} where min and
+            max are the range of values allowed to v. The default range is [-2, 2].
+        quadratic_energy_ranges: Dict of the form {(u, v): (min, max), ...} where min and max are
+            the range of values allowed to (u, v). The default range is [-1, 1].
+        min_classical_gap: A float. The minimum energy gap between the highest feasible state and
+            the lowest infeasible state.
+    """
     # Check for auxiliary variables in the graph
     if len(graph) != len(decision_variables):
         raise ValueError('Penaltymodel-lp does not handle problems with auxiliary variables')

--- a/penaltymodel_lp/penaltymodel/lp/interface.py
+++ b/penaltymodel_lp/penaltymodel/lp/interface.py
@@ -40,6 +40,7 @@ def get_penalty_model(specification):
     try:
         bqm, gap = generate_bqm(specification.graph, feasible_configurations,
                                 specification.decision_variables,
+                                min_classical_gap=specification.min_classical_gap,
                                 linear_energy_ranges=specification.ising_linear_ranges,
                                 quadratic_energy_ranges=quadratic_ranges)
     except ValueError:

--- a/penaltymodel_lp/penaltymodel/lp/interface.py
+++ b/penaltymodel_lp/penaltymodel/lp/interface.py
@@ -40,9 +40,9 @@ def get_penalty_model(specification):
     try:
         bqm, gap = generate_bqm(specification.graph, feasible_configurations,
                                 specification.decision_variables,
-                                min_classical_gap=specification.min_classical_gap,
                                 linear_energy_ranges=specification.ising_linear_ranges,
-                                quadratic_energy_ranges=quadratic_ranges)
+                                quadratic_energy_ranges=quadratic_ranges,
+                                min_classical_gap=specification.min_classical_gap)
     except ValueError:
         raise pm.exceptions.FactoryException("Specification is for too large of a model")
 

--- a/penaltymodel_lp/penaltymodel/lp/package_info.py
+++ b/penaltymodel_lp/penaltymodel/lp/package_info.py
@@ -1,0 +1,4 @@
+__version__ = '0.0.0'
+__author__ = 'D-Wave Systems Inc.'
+__authoremail__ = 'mwong@dwavesys.com'
+__description__ = "Generates penalty models using SciPy's linear programming."

--- a/penaltymodel_lp/setup.py
+++ b/penaltymodel_lp/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 FACTORY_ENTRYPOINT = 'penaltymodel_factory'
 
 install_requires = ['dimod>=0.6.0,<0.9.0',
-                    'penaltymodel>=0.15.0,<0.16.0',
+                    'penaltymodel>=0.15.5,<0.16.0',
                     'scipy>=0.15.0,<2.0.0',
                     'numpy>=0.0.0,<1.16.0'
                     ]

--- a/penaltymodel_lp/setup.py
+++ b/penaltymodel_lp/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 FACTORY_ENTRYPOINT = 'penaltymodel_factory'
 
 install_requires = ['dimod>=0.6.0,<0.9.0',
-                    'penaltymodel>=0.15.5,<0.16.0',
+                    'penaltymodel>=0.16.0,<0.17.0',
                     'scipy>=0.15.0,<2.0.0',
                     'numpy>=0.0.0,<1.16.0'
                     ]

--- a/penaltymodel_lp/test_generation.py
+++ b/penaltymodel_lp/test_generation.py
@@ -57,6 +57,23 @@ class TestPenaltyModelLinearProgramming(unittest.TestCase):
         self.assertGreater(gap, 0)
         self.verify_gate_bqm(bqm, nodes, lambda x, y: -1 * min(x, y))
 
+    def test_min_gap(self):
+        def run_same_problem(min_gap):
+            nodes = ['a', 'b']
+            states = {(-1, -1): -1,
+                      (-1, 1): -1,
+                      (1, -1): -1}
+            return lp.generate_bqm(nx.complete_graph(nodes), states, nodes,
+                                   min_classical_gap=min_gap)
+
+        with self.assertRaises(ValueError):
+            large_min_gap = 5
+            run_same_problem(large_min_gap)
+
+        smaller_min_gap = 4
+        bqm, gap = run_same_problem(smaller_min_gap)
+        self.assertEqual(smaller_min_gap, gap)
+
     def test_linear_energy_range(self):
         # Test linear energy range
         nodes = ['a']

--- a/penaltymodel_lp/test_generation.py
+++ b/penaltymodel_lp/test_generation.py
@@ -58,6 +58,7 @@ class TestPenaltyModelLinearProgramming(unittest.TestCase):
         self.verify_gate_bqm(bqm, nodes, lambda x, y: -1 * min(x, y))
 
     def test_min_gap(self):
+        # Testing that min_classical_gap parameter works
         def run_same_problem(min_gap):
             nodes = ['a', 'b']
             states = {(-1, -1): -1,
@@ -66,10 +67,12 @@ class TestPenaltyModelLinearProgramming(unittest.TestCase):
             return lp.generate_bqm(nx.complete_graph(nodes), states, nodes,
                                    min_classical_gap=min_gap)
 
+        # min_classical_gap=5 should be too large for the problem
         with self.assertRaises(ValueError):
             large_min_gap = 5
             run_same_problem(large_min_gap)
 
+        # Lowering the min_classical_gap should allow a bqm to be found
         smaller_min_gap = 4
         bqm, gap = run_same_problem(smaller_min_gap)
         self.assertEqual(smaller_min_gap, gap)

--- a/penaltymodel_maxgap/penaltymodel/maxgap/generation.py
+++ b/penaltymodel_maxgap/penaltymodel/maxgap/generation.py
@@ -83,9 +83,12 @@ def generate_ising(graph, feasible_configurations, decision_variables,
         for assertion in table.assertions:
             solver.add_assertion(assertion)
 
+        # add min classical gap assertion
+        gap_assertion = table.gap_bound_assertion(min_classical_gap)
+        solver.add_assertion(gap_assertion)
+
         # check if the model is feasible at all.
         if solver.solve():
-
             # we want to increase the gap until we have found the max classical gap
             gmin = min_classical_gap
             gmax = sum(max(abs(r) for r in linear_energy_ranges[v]) for v in graph)

--- a/penaltymodel_maxgap/penaltymodel/maxgap/generation.py
+++ b/penaltymodel_maxgap/penaltymodel/maxgap/generation.py
@@ -36,6 +36,8 @@ def generate_ising(graph, feasible_configurations, decision_variables,
         quadratic_energy_ranges (dict): A dict of the form
             {(u, v): (min, max), ...} where min and max are the range
             of values allowed to (u, v).
+        min_classical_gap (float): The minimum energy gap between the highest feasible state and the
+            lowest infeasible state.
         smt_solver_name (str/None): The name of the smt solver. Must
             be a solver available to pysmt. If None, uses the pysmt default.
 

--- a/penaltymodel_maxgap/penaltymodel/maxgap/generation.py
+++ b/penaltymodel_maxgap/penaltymodel/maxgap/generation.py
@@ -89,6 +89,9 @@ def generate_ising(graph, feasible_configurations, decision_variables,
 
         # check if the model is feasible at all.
         if solver.solve():
+            # since we know the current model is feasible, grab the initial model.
+            model = solver.get_model()
+
             # we want to increase the gap until we have found the max classical gap
             gmin = min_classical_gap
             gmax = sum(max(abs(r) for r in linear_energy_ranges[v]) for v in graph)

--- a/penaltymodel_maxgap/penaltymodel/maxgap/interface.py
+++ b/penaltymodel_maxgap/penaltymodel/maxgap/interface.py
@@ -41,6 +41,7 @@ def get_penalty_model(specification):
                                                     specification.decision_variables,
                                                     specification.ising_linear_ranges,
                                                     quadratic_ranges,
+                                                    specification.min_classical_gap,
                                                     None)  # unspecified smt solver
 
     # set of the model with 0.0 offset

--- a/penaltymodel_maxgap/penaltymodel/maxgap/package_info.py
+++ b/penaltymodel_maxgap/penaltymodel/maxgap/package_info.py
@@ -1,4 +1,4 @@
-__version__ = '0.4.2'
+__version__ = '0.5.0'
 __author__ = 'D-Wave Systems Inc.'
 __authoremail__ = 'acondello@dwavesys.com'
 __description__ = 'Generates penalty models using smt solvers.'

--- a/penaltymodel_maxgap/setup.py
+++ b/penaltymodel_maxgap/setup.py
@@ -48,7 +48,7 @@ setup_requires = ['pysmt==0.7.0']
 
 install_requires = ['dimod>=0.6.3,<0.9.0',
                     'dwave_networkx>=0.6.0,<0.7.0',
-                    'penaltymodel>=0.15.0,<0.16.0',
+                    'penaltymodel>=0.15.5,<0.16.0',
                     'pysmt==0.7.0',
                     'six>=1.11.0,<2.0.0',
                     ]

--- a/penaltymodel_maxgap/setup.py
+++ b/penaltymodel_maxgap/setup.py
@@ -48,7 +48,7 @@ setup_requires = ['pysmt==0.7.0']
 
 install_requires = ['dimod>=0.6.3,<0.9.0',
                     'dwave_networkx>=0.6.0,<0.7.0',
-                    'penaltymodel>=0.15.5,<0.16.0',
+                    'penaltymodel>=0.16.0,<0.17.0',
                     'pysmt==0.7.0',
                     'six>=1.11.0,<2.0.0',
                     ]

--- a/penaltymodel_maxgap/tests/test_generation.py
+++ b/penaltymodel_maxgap/tests/test_generation.py
@@ -290,3 +290,31 @@ class TestGeneration(unittest.TestCase):
         _, _, _, gap = run_same_problem(smaller_min_gap)
         self.assertGreaterEqual(gap, smaller_min_gap)
 
+    def test_min_gap_with_aux(self):
+        # Verify min_classical_gap parameter works
+        def run_same_problem(min_classical_gap):
+            decision_variables = ['a', 'b', 'c']
+            xor_gate = {(-1, -1, -1): 0,
+                       (-1, 1, 1): 0,
+                       (1, -1, 1): 0,
+                       (1, 1, 1): 0}
+            graph = nx.complete_graph(decision_variables + ['aux0'])
+
+            linear_energy_ranges = {v: (-2., 2.) for v in graph}
+            quadratic_energy_ranges = {(u, v): (-1., 1.) for u, v in graph.edges}
+
+            return maxgap.generate_ising(graph, xor_gate, decision_variables,
+                                         linear_energy_ranges,
+                                         quadratic_energy_ranges,
+                                         min_classical_gap,
+                                         None)
+
+        # Run problem with a min_classical_gap that is too large
+        with self.assertRaises(pm.ImpossiblePenaltyModel):
+            large_min_gap = 4.5
+            run_same_problem(large_min_gap)
+
+        # Lowering min_classical_gap should lead to a bqm being found
+        smaller_min_gap = 3.5
+        _, _, _, gap = run_same_problem(smaller_min_gap)
+        self.assertGreaterEqual(gap, smaller_min_gap)

--- a/penaltymodel_maxgap/tests/test_generation.py
+++ b/penaltymodel_maxgap/tests/test_generation.py
@@ -250,7 +250,7 @@ class TestGeneration(unittest.TestCase):
 
         linear_energy_ranges = {v: (-2., 2.) for v in graph}
         quadratic_energy_ranges = {(u, v): (-1., 1.) for u, v in graph.edges}
-        min_classical_gap = 2
+        min_classical_gap = 1
 
         h, J, offset, gap = maxgap.generate_ising(graph, configurations, decision_variables,
                                                   linear_energy_ranges,

--- a/penaltymodel_maxgap/tests/test_generation.py
+++ b/penaltymodel_maxgap/tests/test_generation.py
@@ -26,11 +26,13 @@ class TestGeneration(unittest.TestCase):
         decision_variables = (0, 1, 2)
         linear_energy_ranges = {v: (-2., 2.) for v in graph}
         quadratic_energy_ranges = {(u, v): (-1., 1.) for u, v in graph.edges}
+        min_classical_gap = 2
 
         with self.assertRaises(pm.ImpossiblePenaltyModel):
             maxgap.generate_ising(graph, configurations, decision_variables,
                                   linear_energy_ranges,
                                   quadratic_energy_ranges,
+                                  min_classical_gap,
                                   None)
 
     def check_linear_energy_ranges(self, linear, linear_energy_ranges):
@@ -92,10 +94,12 @@ class TestGeneration(unittest.TestCase):
         decision_variables = (0, 1, 2)
         linear_energy_ranges = {v: (-2., 2.) for v in graph}
         quadratic_energy_ranges = {(u, v): (-1., 1.) for u, v in graph.edges}
+        min_classical_gap = 2
 
         h, J, offset, gap = maxgap.generate_ising(graph, configurations, decision_variables,
                                                   linear_energy_ranges,
                                                   quadratic_energy_ranges,
+                                                  min_classical_gap,
                                                   None)
         self.check_generated_ising_model(configurations, decision_variables, h, J, offset, gap)
         self.check_linear_energy_ranges(h, linear_energy_ranges)
@@ -111,10 +115,12 @@ class TestGeneration(unittest.TestCase):
         decision_variables = (0, 1, 2)
         linear_energy_ranges = {v: (-1., 2.) for v in graph}
         quadratic_energy_ranges = {(u, v): (-1., .5) for u, v in graph.edges}
+        min_classical_gap = 2
 
         h, J, offset, gap = maxgap.generate_ising(graph, configurations, decision_variables,
                                                   linear_energy_ranges,
                                                   quadratic_energy_ranges,
+                                                  min_classical_gap,
                                                   None)
         self.check_generated_ising_model(configurations, decision_variables, h, J, offset, gap)
         self.check_linear_energy_ranges(h, linear_energy_ranges)
@@ -130,10 +136,12 @@ class TestGeneration(unittest.TestCase):
 
         linear_energy_ranges = {v: (-2., 2.) for v in graph}
         quadratic_energy_ranges = {(u, v): (-1., 1.) for u, v in graph.edges}
+        min_classical_gap = 2
 
         h, J, offset, gap = maxgap.generate_ising(graph, configurations, decision_variables,
                                                   linear_energy_ranges,
                                                   quadratic_energy_ranges,
+                                                  min_classical_gap,
                                                   None)
         self.check_generated_ising_model(configurations, decision_variables, h, J, offset, gap)
         self.check_linear_energy_ranges(h, linear_energy_ranges)
@@ -148,10 +156,12 @@ class TestGeneration(unittest.TestCase):
 
         linear_energy_ranges = {v: (-2., 2.) for v in graph}
         quadratic_energy_ranges = {(u, v): (-1., 1.) for u, v in graph.edges}
+        min_classical_gap = 2
 
         h, J, offset, gap = maxgap.generate_ising(graph, configurations, decision_variables,
                                                   linear_energy_ranges,
                                                   quadratic_energy_ranges,
+                                                  min_classical_gap,
                                                   None)
         self.check_generated_ising_model(configurations, decision_variables, h, J, offset, gap)
         self.check_linear_energy_ranges(h, linear_energy_ranges)
@@ -165,10 +175,12 @@ class TestGeneration(unittest.TestCase):
 
         linear_energy_ranges = {v: (-2., 2.) for v in graph}
         quadratic_energy_ranges = {(u, v): (-1., 1.) for u, v in graph.edges}
+        min_classical_gap = 2
 
         h, J, offset, gap = maxgap.generate_ising(graph, configurations, decision_variables,
                                                   linear_energy_ranges,
                                                   quadratic_energy_ranges,
+                                                  min_classical_gap,
                                                   None)
         self.check_generated_ising_model(configurations, decision_variables, h, J, offset, gap)
         self.check_linear_energy_ranges(h, linear_energy_ranges)
@@ -182,10 +194,12 @@ class TestGeneration(unittest.TestCase):
         linear_energy_ranges = {v: (-2., 2.) for v in graph}
         quadratic_energy_ranges = {(u, v): (-1., 1.) for u, v in graph.edges}
         decision_variables = [0, 1]
+        min_classical_gap = 2
 
         h, J, offset, gap = maxgap.generate_ising(graph, configurations, decision_variables,
                                                   linear_energy_ranges,
                                                   quadratic_energy_ranges,
+                                                  min_classical_gap,
                                                   None)
         self.check_generated_ising_model(configurations, decision_variables, h, J, offset, gap)
         self.check_linear_energy_ranges(h, linear_energy_ranges)
@@ -219,10 +233,12 @@ class TestGeneration(unittest.TestCase):
         decision_variables = [0, 1]
         linear_energy_ranges = {v: (-2., 2.) for v in graph}
         quadratic_energy_ranges = {(u, v): (-1., 1.) for u, v in graph.edges}
+        min_classical_gap = 2
 
         h, J, offset, gap = maxgap.generate_ising(graph, configurations, decision_variables,
                                                   linear_energy_ranges,
                                                   quadratic_energy_ranges,
+                                                  min_classical_gap,
                                                   'z3')
         self.check_generated_ising_model(configurations, decision_variables, h, J, offset, gap)
 
@@ -234,11 +250,42 @@ class TestGeneration(unittest.TestCase):
 
         linear_energy_ranges = {v: (-2., 2.) for v in graph}
         quadratic_energy_ranges = {(u, v): (-1., 1.) for u, v in graph.edges}
+        min_classical_gap = 2
 
         h, J, offset, gap = maxgap.generate_ising(graph, configurations, decision_variables,
                                                   linear_energy_ranges,
                                                   quadratic_energy_ranges,
+                                                  min_classical_gap,
                                                   None)
         self.check_generated_ising_model(configurations, decision_variables, h, J, offset, gap)
         self.check_linear_energy_ranges(h, linear_energy_ranges)
         self.check_quadratic_energy_ranges(J, quadratic_energy_ranges)
+
+    def test_min_gap_no_aux(self):
+        # Verify min_classical_gap parameter works
+        def run_same_problem(min_classical_gap):
+            decision_variables = ['a', 'b']
+            configurations = {(-1, -1): 0,
+                              (-1, 1): 0,
+                              (1, -1): 0}
+            graph = nx.complete_graph(decision_variables)
+
+            linear_energy_ranges = {v: (-2., 2.) for v in graph}
+            quadratic_energy_ranges = {(u, v): (-1., 1.) for u, v in graph.edges}
+
+            return maxgap.generate_ising(graph, configurations, decision_variables,
+                                         linear_energy_ranges,
+                                         quadratic_energy_ranges,
+                                         min_classical_gap,
+                                         None)
+
+        # Run problem with a min_classical_gap that is too large
+        with self.assertRaises(pm.ImpossiblePenaltyModel):
+            large_min_gap = 5
+            run_same_problem(large_min_gap)
+
+        # Lowering min_classical_gap should lead to a bqm being found
+        smaller_min_gap = 4
+        _, _, _, gap = run_same_problem(smaller_min_gap)
+        self.assertEqual(smaller_min_gap, gap)
+

--- a/penaltymodel_maxgap/tests/test_generation.py
+++ b/penaltymodel_maxgap/tests/test_generation.py
@@ -264,16 +264,17 @@ class TestGeneration(unittest.TestCase):
     def test_min_gap_no_aux(self):
         # Verify min_classical_gap parameter works
         def run_same_problem(min_classical_gap):
-            decision_variables = ['a', 'b']
-            configurations = {(-1, -1): 0,
-                              (-1, 1): 0,
-                              (1, -1): 0}
+            decision_variables = ['a', 'b', 'c']
+            or_gate = {(-1, -1, -1): 0,
+                       (-1, 1, 1): 0,
+                       (1, -1, 1): 0,
+                       (1, 1, 1): 0}
             graph = nx.complete_graph(decision_variables)
 
             linear_energy_ranges = {v: (-2., 2.) for v in graph}
             quadratic_energy_ranges = {(u, v): (-1., 1.) for u, v in graph.edges}
 
-            return maxgap.generate_ising(graph, configurations, decision_variables,
+            return maxgap.generate_ising(graph, or_gate, decision_variables,
                                          linear_energy_ranges,
                                          quadratic_energy_ranges,
                                          min_classical_gap,
@@ -281,11 +282,11 @@ class TestGeneration(unittest.TestCase):
 
         # Run problem with a min_classical_gap that is too large
         with self.assertRaises(pm.ImpossiblePenaltyModel):
-            large_min_gap = 5
+            large_min_gap = 3
             run_same_problem(large_min_gap)
 
         # Lowering min_classical_gap should lead to a bqm being found
-        smaller_min_gap = 4
+        smaller_min_gap = 1.5
         _, _, _, gap = run_same_problem(smaller_min_gap)
-        self.assertEqual(smaller_min_gap, gap)
+        self.assertGreaterEqual(gap, smaller_min_gap)
 

--- a/penaltymodel_maxgap/tests/test_generation.py
+++ b/penaltymodel_maxgap/tests/test_generation.py
@@ -359,3 +359,25 @@ class TestGeneration(unittest.TestCase):
         smaller_min_gap = 0.5
         _, _, _, gap = run_same_problem(smaller_min_gap)
         self.assertGreaterEqual(gap, smaller_min_gap)
+
+    def test_min_gap_equals_max_gap(self):
+        # Make sure that a model is always grabbed, even when min_gap == max_gap
+        min_gap = 2     # This value is also the max classical gap
+        decision_variables = ['a']
+        config = {(-1,): -1}
+        graph = nx.complete_graph(decision_variables)
+
+        linear_energy_ranges = {v: (-2., 2.) for v in graph}
+        quadratic_energy_ranges = {(u, v): (-1., 1.) for u, v in graph.edges}
+
+        h, J, offset, gap = maxgap.generate_ising(graph, config, decision_variables,
+                                                  linear_energy_ranges,
+                                                  quadratic_energy_ranges,
+                                                  min_gap,
+                                                  None)
+
+        # Check that a model was found
+        self.assertIsNotNone(h)
+        self.assertIsNotNone(J)
+        self.assertIsNotNone(offset)
+        self.assertEqual(min_gap, gap)  # Min gap is also the max classical gap in this case

--- a/penaltymodel_maxgap/tests/test_generation.py
+++ b/penaltymodel_maxgap/tests/test_generation.py
@@ -261,6 +261,47 @@ class TestGeneration(unittest.TestCase):
         self.check_linear_energy_ranges(h, linear_energy_ranges)
         self.check_quadratic_energy_ranges(J, quadratic_energy_ranges)
 
+    def test_negative_min_gap_impossible_bqm(self):
+        # XOR Gate problem without auxiliary variables
+        # Note: Regardless of the negative gap, this BQM should remain impossible.
+        negative_gap = -3
+        decision_variables = ['a', 'b', 'c']
+        xor_gate = {(-1, -1, -1): 0,
+                    (-1, 1, 1): 0,
+                    (1, -1, 1): 0,
+                    (1, 1, -1): 0}
+        graph = nx.complete_graph(decision_variables)
+
+        linear_energy_ranges = {v: (-2., 2.) for v in graph}
+        quadratic_energy_ranges = {(u, v): (-1., 1.) for u, v in graph.edges}
+
+        with self.assertRaises(pm.ImpossiblePenaltyModel):
+            maxgap.generate_ising(graph, xor_gate, decision_variables,
+                                  linear_energy_ranges,
+                                  quadratic_energy_ranges,
+                                  negative_gap,
+                                  None)
+
+    def test_negative_min_gap_feasible_bqm(self):
+        # Regardless of the negative min classical gap, this feasible BQM should return its usual
+        # max classical gap.
+        negative_gap = -2
+        decision_variables = ['a']
+        config = {(-1,): -1}
+        graph = nx.complete_graph(decision_variables)
+
+        linear_energy_ranges = {v: (-2., 2.) for v in graph}
+        quadratic_energy_ranges = {(u, v): (-1., 1.) for u, v in graph.edges}
+
+        _, _, _, gap = maxgap.generate_ising(graph, config, decision_variables,
+                                             linear_energy_ranges,
+                                             quadratic_energy_ranges,
+                                             negative_gap,
+                                             None)
+
+        expected_gap = 2
+        self.assertEqual(expected_gap, gap)
+
     def test_min_gap_no_aux(self):
         # Verify min_classical_gap parameter works
         def run_same_problem(min_classical_gap):
@@ -295,9 +336,9 @@ class TestGeneration(unittest.TestCase):
         def run_same_problem(min_classical_gap):
             decision_variables = ['a', 'b', 'c']
             xor_gate = {(-1, -1, -1): 0,
-                       (-1, 1, 1): 0,
-                       (1, -1, 1): 0,
-                       (1, 1, 1): 0}
+                        (-1, 1, 1): 0,
+                        (1, -1, 1): 0,
+                        (1, 1, -1): 0}
             graph = nx.complete_graph(decision_variables + ['aux0'])
 
             linear_energy_ranges = {v: (-2., 2.) for v in graph}
@@ -311,10 +352,10 @@ class TestGeneration(unittest.TestCase):
 
         # Run problem with a min_classical_gap that is too large
         with self.assertRaises(pm.ImpossiblePenaltyModel):
-            large_min_gap = 4.5
+            large_min_gap = 2
             run_same_problem(large_min_gap)
 
         # Lowering min_classical_gap should lead to a bqm being found
-        smaller_min_gap = 3.5
+        smaller_min_gap = 0.5
         _, _, _, gap = run_same_problem(smaller_min_gap)
         self.assertGreaterEqual(gap, smaller_min_gap)

--- a/penaltymodel_mip/penaltymodel/mip/generation.py
+++ b/penaltymodel_mip/penaltymodel/mip/generation.py
@@ -12,8 +12,7 @@ import penaltymodel.core as pm
 
 
 def generate_bqm(graph, table, decision,
-                 min_classical_gap=2,
-                 linear_energy_ranges=None, quadratic_energy_ranges=None,
+                 linear_energy_ranges=None, quadratic_energy_ranges=None, min_classical_gap=2,
                  precision=7, max_decision=8, max_variables=10,
                  return_auxiliary=False):
     """Get a binary quadratic model with specific ground states.

--- a/penaltymodel_mip/penaltymodel/mip/generation.py
+++ b/penaltymodel_mip/penaltymodel/mip/generation.py
@@ -12,6 +12,7 @@ import penaltymodel.core as pm
 
 
 def generate_bqm(graph, table, decision,
+                 min_classical_gap=2,
                  linear_energy_ranges=None, quadratic_energy_ranges=None,
                  precision=7, max_decision=8, max_variables=10,
                  return_auxiliary=False):
@@ -106,11 +107,11 @@ def generate_bqm(graph, table, decision,
         quadratic_energy_ranges = defaultdict(lambda: (-1, 1))
 
     if return_auxiliary:
-        h, J, offset, gap, aux = _generate_ising(graph, table, decision,
+        h, J, offset, gap, aux = _generate_ising(graph, table, decision, min_classical_gap,
                                                  linear_energy_ranges, quadratic_energy_ranges,
                                                  return_auxiliary)
     else:
-        h, J, offset, gap = _generate_ising(graph, table, decision,
+        h, J, offset, gap = _generate_ising(graph, table, decision, min_classical_gap,
                                             linear_energy_ranges, quadratic_energy_ranges,
                                             return_auxiliary)
 
@@ -125,8 +126,8 @@ def generate_bqm(graph, table, decision,
         return bqm, round(gap, precision)
 
 
-def _generate_ising(graph, table, decision, linear_energy_ranges, quadratic_energy_ranges,
-                    return_auxiliary):
+def _generate_ising(graph, table, decision, min_classical_gap, linear_energy_ranges,
+                    quadratic_energy_ranges, return_auxiliary):
 
     if not table:
         # if there are no feasible configurations then the gap is 0 and the model is empty
@@ -157,7 +158,7 @@ def _generate_ising(graph, table, decision, linear_energy_ranges, quadratic_ener
 
     offset = solver.NumVar(-solver.infinity(), solver.infinity(), 'offset')
 
-    gap = solver.NumVar(0, solver.infinity(), 'classical_gap')
+    gap = solver.NumVar(min_classical_gap, solver.infinity(), 'classical_gap')
 
     # Let x, a be the decision, auxiliary variables respectively
     # Let E(x, a) be the energy of x and a

--- a/penaltymodel_mip/penaltymodel/mip/generation.py
+++ b/penaltymodel_mip/penaltymodel/mip/generation.py
@@ -84,7 +84,8 @@ def generate_bqm(graph, table, decision,
 
     if not set().union(*table).issubset({-1, 1}):
         raise ValueError("expected table to be spin-valued")
-    elif isinstance(table, Mapping) and any(table.values()):
+
+    if isinstance(table, Mapping) and any(table.values()):
         raise ValueError("cannot handle non-zero target energy levels")
 
     if not isinstance(decision, list):

--- a/penaltymodel_mip/penaltymodel/mip/generation.py
+++ b/penaltymodel_mip/penaltymodel/mip/generation.py
@@ -36,6 +36,10 @@ def generate_bqm(graph, table, decision,
             Dict of the form {(u, v): (min, max), ...} where min and max are the range of values
             allowed to (u, v). The default range is [-1, 1].
 
+        min_classical_gap (float):
+            The minimum energy gap between the highest feasible state and the lowest infeasible
+            state.
+
         precision (int, optional, default=7):
             Values returned by the optimization solver are rounded to `precision` digits of
             precision.

--- a/penaltymodel_mip/penaltymodel/mip/interface.py
+++ b/penaltymodel_mip/penaltymodel/mip/interface.py
@@ -41,9 +41,9 @@ def get_penalty_model(specification):
     try:
         bqm, gap = generate_bqm(specification.graph, feasible_configurations,
                                 specification.decision_variables,
-                                min_classical_gap=specification.min_classical_gap,
                                 linear_energy_ranges=specification.ising_linear_ranges,
-                                quadratic_energy_ranges=quadratic_ranges)
+                                quadratic_energy_ranges=quadratic_ranges,
+                                min_classical_gap=specification.min_classical_gap)
     except ValueError:
         raise pm.exceptions.FactoryException("Specification is for too large of a model")
 

--- a/penaltymodel_mip/penaltymodel/mip/interface.py
+++ b/penaltymodel_mip/penaltymodel/mip/interface.py
@@ -41,6 +41,7 @@ def get_penalty_model(specification):
     try:
         bqm, gap = generate_bqm(specification.graph, feasible_configurations,
                                 specification.decision_variables,
+                                min_classical_gap=specification.min_classical_gap,
                                 linear_energy_ranges=specification.ising_linear_ranges,
                                 quadratic_energy_ranges=quadratic_ranges)
     except ValueError:

--- a/penaltymodel_mip/penaltymodel/mip/package_info.py
+++ b/penaltymodel_mip/penaltymodel/mip/package_info.py
@@ -1,4 +1,4 @@
-__version__ = '0.1.4'
+__version__ = '0.2.0'
 __author__ = 'D-Wave Systems Inc.'
 __authoremail__ = 'acondello@dwavesys.com'
 __description__ = "Generates penalty models using Google Optimization Tools' Mixed-Integer Programming capability."

--- a/penaltymodel_mip/setup.py
+++ b/penaltymodel_mip/setup.py
@@ -14,7 +14,7 @@ else:
 install_requires = ['dimod>=0.6.0,<0.9.0',
                     'networkx>=2.0,<3.0',
                     'ortools>=6.6.4659,<7.0.0',
-                    'penaltymodel>=0.15.0,<0.16.0',
+                    'penaltymodel>=0.15.5,<0.16.0',
                     ]
 
 packages = ['penaltymodel',

--- a/penaltymodel_mip/setup.py
+++ b/penaltymodel_mip/setup.py
@@ -14,7 +14,7 @@ else:
 install_requires = ['dimod>=0.6.0,<0.9.0',
                     'networkx>=2.0,<3.0',
                     'ortools>=6.6.4659,<7.0.0',
-                    'penaltymodel>=0.15.5,<0.16.0',
+                    'penaltymodel>=0.16.0,<0.17.0',
                     ]
 
 packages = ['penaltymodel',

--- a/penaltymodel_mip/tests/test_generation.py
+++ b/penaltymodel_mip/tests/test_generation.py
@@ -264,40 +264,41 @@ class TestGeneration(unittest.TestCase):
             self.assertAlmostEqual(bqm.energy(sample), 0.0)
 
     def test_min_gap_no_aux(self):
-        # Verify min_classical_gap parameter works.
+        # Verify min_classical_gap parameter works
         # Note: test will run the problem with a gap of 5, where the gap is too high. Lowering
         #   gap to 4 should produce a BQM.
-        def run_same_problem(min_gap):
-            nodes = ['a', 'b']
-            states = {(-1, -1): 0,
-                      (-1, 1): 0,
-                      (1, -1): 0}
-            return mip.generate_bqm(nx.complete_graph(nodes), states, nodes,
-                                    min_classical_gap=min_gap)
 
+        # Set up problem
+        nodes = ['a', 'b']
+        states = {(-1, -1): 0,
+                  (-1, 1): 0,
+                  (1, -1): 0}
+        graph = nx.complete_graph(nodes)
+        bqm, gap = mip.generate_bqm(graph, states, nodes, min_classical_gap=smaller_min_gap)
+        # Run problem with a min_classical_gap that is set too high
         with self.assertRaises(pm.ImpossiblePenaltyModel):
             large_min_gap = 5
-            run_same_problem(large_min_gap)
+            mip.generate_bqm(graph, states, nodes, min_classical_gap=large_min_gap)
 
+        # Run same problem with the min_classical_gap set to a lower threshold
         smaller_min_gap = 4
-        bqm, gap = run_same_problem(smaller_min_gap)
+        bqm, gap = mip.generate_bqm(graph, states, nodes, min_classical_gap=smaller_min_gap)
         self.assertEqual(smaller_min_gap, gap)
+        self.check_bqm_table(bqm, gap, states, nodes)
 
     def test_min_gap_with_auxiliary(self):
         # Verify min_classical_gap parameter works.
-        def run_same_problem(min_gap):
-            nodes = ['a']
-            states = {(-1,): 0}
-            graph = nx.complete_graph(nodes + ['aux0'])
-
-            return mip.generate_bqm(graph, states, nodes, min_classical_gap=min_gap)
+        nodes = ['a']
+        states = {(-1,): 0}
+        graph = nx.complete_graph(nodes + ['aux0'])
 
         # min_classical_gap should be too large for this problem
         with self.assertRaises(pm.ImpossiblePenaltyModel):
             large_min_gap = 7
-            run_same_problem(large_min_gap)
+            mip.generate_bqm(graph, states, nodes, min_classical_gap=large_min_gap)
 
         # Lowering the min_classical_gap should result to a bqm being found
         smaller_min_gap = 6
-        bqm, gap = run_same_problem(smaller_min_gap)
+        bqm, gap = mip.generate_bqm(graph, states, nodes, min_classical_gap=smaller_min_gap)
         self.assertEqual(smaller_min_gap, gap)
+        self.check_bqm_table(bqm, gap, states, nodes)

--- a/penaltymodel_mip/tests/test_generation.py
+++ b/penaltymodel_mip/tests/test_generation.py
@@ -264,6 +264,9 @@ class TestGeneration(unittest.TestCase):
             self.assertAlmostEqual(bqm.energy(sample), 0.0)
 
     def test_min_gap_no_aux(self):
+        # Verify min_classical_gap parameter works.
+        # Note: test will run the problem with a gap of 5, where the gap is too high. Lowering
+        #   gap to 4 should produce a BQM.
         def run_same_problem(min_gap):
             nodes = ['a', 'b']
             states = {(-1, -1): 0,
@@ -277,5 +280,24 @@ class TestGeneration(unittest.TestCase):
             run_same_problem(large_min_gap)
 
         smaller_min_gap = 4
+        bqm, gap = run_same_problem(smaller_min_gap)
+        self.assertEqual(smaller_min_gap, gap)
+
+    def test_min_gap_with_auxiliary(self):
+        # Verify min_classical_gap parameter works.
+        # Note: test will run the problem with a gap of 7, where the gap is too high. Lowering
+        #   gap to 6 should produce a BQM.
+        def run_same_problem(min_gap):
+            nodes = ['a']
+            states = {(-1,): 0}
+            graph = nx.complete_graph(nodes + ['aux0'])
+
+            return mip.generate_bqm(graph, states, nodes, min_classical_gap=min_gap)
+
+        with self.assertRaises(pm.ImpossiblePenaltyModel):
+            large_min_gap = 7
+            run_same_problem(large_min_gap)
+
+        smaller_min_gap = 6
         bqm, gap = run_same_problem(smaller_min_gap)
         self.assertEqual(smaller_min_gap, gap)

--- a/penaltymodel_mip/tests/test_generation.py
+++ b/penaltymodel_mip/tests/test_generation.py
@@ -262,3 +262,20 @@ class TestGeneration(unittest.TestCase):
             sample.update(aux_configs[config])
 
             self.assertAlmostEqual(bqm.energy(sample), 0.0)
+
+    def test_min_gap_no_aux(self):
+        def run_same_problem(min_gap):
+            nodes = ['a', 'b']
+            states = {(-1, -1): 0,
+                      (-1, 1): 0,
+                      (1, -1): 0}
+            return mip.generate_bqm(nx.complete_graph(nodes), states, nodes,
+                                    min_classical_gap=min_gap)
+
+        with self.assertRaises(pm.ImpossiblePenaltyModel):
+            large_min_gap = 5
+            run_same_problem(large_min_gap)
+
+        smaller_min_gap = 4
+        bqm, gap = run_same_problem(smaller_min_gap)
+        self.assertEqual(smaller_min_gap, gap)

--- a/penaltymodel_mip/tests/test_generation.py
+++ b/penaltymodel_mip/tests/test_generation.py
@@ -285,8 +285,6 @@ class TestGeneration(unittest.TestCase):
 
     def test_min_gap_with_auxiliary(self):
         # Verify min_classical_gap parameter works.
-        # Note: test will run the problem with a gap of 7, where the gap is too high. Lowering
-        #   gap to 6 should produce a BQM.
         def run_same_problem(min_gap):
             nodes = ['a']
             states = {(-1,): 0}
@@ -294,10 +292,12 @@ class TestGeneration(unittest.TestCase):
 
             return mip.generate_bqm(graph, states, nodes, min_classical_gap=min_gap)
 
+        # min_classical_gap should be too large for this problem
         with self.assertRaises(pm.ImpossiblePenaltyModel):
             large_min_gap = 7
             run_same_problem(large_min_gap)
 
+        # Lowering the min_classical_gap should result to a bqm being found
         smaller_min_gap = 6
         bqm, gap = run_same_problem(smaller_min_gap)
         self.assertEqual(smaller_min_gap, gap)

--- a/penaltymodel_mip/tests/test_generation.py
+++ b/penaltymodel_mip/tests/test_generation.py
@@ -274,7 +274,7 @@ class TestGeneration(unittest.TestCase):
                   (-1, 1): 0,
                   (1, -1): 0}
         graph = nx.complete_graph(nodes)
-        bqm, gap = mip.generate_bqm(graph, states, nodes, min_classical_gap=smaller_min_gap)
+
         # Run problem with a min_classical_gap that is set too high
         with self.assertRaises(pm.ImpossiblePenaltyModel):
             large_min_gap = 5


### PR DESCRIPTION
Closes #70.

- Made changes so that min classical gap can now be added as a direct constraint in each penalty model (MIP, MaxGap, LP)
- Add corresponding unit tests to verify that the min classical gap parameter works