### PR TITLE
Remove dwave-networkx version upper bound

### DIFF
--- a/penaltymodel_maxgap/setup.py
+++ b/penaltymodel_maxgap/setup.py
@@ -47,7 +47,7 @@ class PysmtSolverInstall(install):
 setup_requires = ['pysmt==0.7.0']
 
 install_requires = ['dimod>=0.8.0,<0.9.0',
-                    'dwave-networkx>=0.6.0,<0.7.0',
+                    'dwave_networkx>=0.6.0',
                     'penaltymodel>=0.16.0,<0.17.0',
                     'pysmt==0.7.0',
                     ]


### PR DESCRIPTION
We only use a single function from dwave-networkx and that function is not likely to change. I think it is safe to remove the upper bound.

Fix needed for dwavesystems/dwave-ocean-sdk#24