### PR TITLE
Feature/68 mip to consider multiple energy states

### DIFF
--- a/penaltymodel_mip/penaltymodel/mip/generation.py
+++ b/penaltymodel_mip/penaltymodel/mip/generation.py
@@ -270,6 +270,9 @@ def _generate_ising(graph, table, decision, min_classical_gap, linear_energy_ran
     offset = offset.solution_value()
     gap = gap.solution_value()
 
+    if decision and not auxiliary and len(table) == 2*len(decision):
+        gap = float('inf')
+
     if not gap:
         raise pm.ImpossiblePenaltyModel("No positive gap can be found for the given model")
 

--- a/penaltymodel_mip/penaltymodel/mip/generation.py
+++ b/penaltymodel_mip/penaltymodel/mip/generation.py
@@ -11,9 +11,9 @@ from ortools.linear_solver import pywraplp
 import penaltymodel.core as pm
 
 
-#TODO: think of a more elegant way to support both dict and lists
 def get(iterable, key, default_value):
-    """This is a helper function to assist with supporting both dictionary and list functionality.
+    """This is a helper function to assist with supporting both dictionary and list/set
+    functionality.
     """
     if isinstance(iterable, dict):
         return iterable.get(key, default_value)
@@ -235,7 +235,6 @@ def _generate_ising(graph, table, decision, min_classical_gap, linear_energy_ran
                 coefficients[offset] = 1
 
                 # # the -100*|| a - a*(x) || term
-                auxiliary_coefficients = {}
                 for v in auxiliary:
                     # we don't have absolute value, so we check what a is and order the subtraction accordingly
                     if spins[v] == -1:
@@ -262,7 +261,8 @@ def _generate_ising(graph, table, decision, min_classical_gap, linear_energy_ran
     objective.SetCoefficient(gap, 1)
     objective.SetMaximization()
 
-    result_status = solver.Solve()
+    # run solver
+    solver.Solve()
 
     # read everything back into floats
     h = {v: bias.solution_value() for v, bias in h.items()}

--- a/penaltymodel_mip/penaltymodel/mip/generation.py
+++ b/penaltymodel_mip/penaltymodel/mip/generation.py
@@ -243,7 +243,7 @@ def _generate_ising(graph, table, decision, min_classical_gap, linear_energy_ran
             const = solver.Constraint(val, val)  # equality constraint
             const.SetCoefficient(var, 1)
 
-    if auxiliary or len(table) != 2*len(decision):
+    if auxiliary or len(table) != 2**len(decision):
         objective = solver.Objective()
         objective.SetCoefficient(gap, 1)
         objective.SetMaximization()

--- a/penaltymodel_mip/penaltymodel/mip/generation.py
+++ b/penaltymodel_mip/penaltymodel/mip/generation.py
@@ -204,8 +204,8 @@ def _generate_ising(graph, table, decision, min_classical_gap, linear_energy_ran
         for decision_config in table:
             spins = dict(zip(decision, decision_config))
 
-            upper_bound = get(table, decision_config, highest_target_energy)
-            const = solver.Constraint(-solver.infinity(), upper_bound)
+            target_energy = get(table, decision_config, highest_target_energy)
+            const = solver.Constraint(-solver.infinity(), target_energy)
 
             # add the energy for the configuration
             for v, bias in h.items():

--- a/penaltymodel_mip/penaltymodel/mip/generation.py
+++ b/penaltymodel_mip/penaltymodel/mip/generation.py
@@ -222,7 +222,7 @@ def _generate_ising(graph, table, decision, min_classical_gap, linear_energy_ran
         a_star = {config: {v: solver.IntVar(0, 1, 'a*(%s)_%s' % (config, v)) for v in auxiliary} for config in table}
 
         for decision_config in table:
-            target_energy = get(table, decision_config, 0)
+            target_energy = get(table, decision_config, highest_target_energy)
 
             for aux_config in itertools.product((-1, 1), repeat=len(variables) - len(decision)):
                 spins = dict(zip(variables, decision_config+aux_config))

--- a/penaltymodel_mip/penaltymodel/mip/generation.py
+++ b/penaltymodel_mip/penaltymodel/mip/generation.py
@@ -85,9 +85,6 @@ def generate_bqm(graph, table, decision,
     if not set().union(*table).issubset({-1, 1}):
         raise ValueError("expected table to be spin-valued")
 
-    if isinstance(table, Mapping) and any(table.values()):
-        raise ValueError("cannot handle non-zero target energy levels")
-
     if not isinstance(decision, list):
         decision = list(decision)  # handle iterables
     if not all(v in graph for v in decision):

--- a/penaltymodel_mip/tests/test_generation.py
+++ b/penaltymodel_mip/tests/test_generation.py
@@ -343,11 +343,13 @@ class TestGeneration(unittest.TestCase):
         """
 
         nodes = ['a', 'b']
-        graph = nx.complete_graph(nodes + ['aux0'])
+        graph = nx.complete_graph(nodes + ['c'])
         configurations = {(+1, +1): -3,
                           (+1, -1): -6}
 
         bqm, gap = mip.generate_bqm(graph, configurations, nodes, min_classical_gap=0)
+
+        self.check_bqm_table(bqm, gap, configurations, nodes)
         self.check_bqm_graph(bqm, graph)
 
     def test_all_possible_config(self):

--- a/penaltymodel_mip/tests/test_generation.py
+++ b/penaltymodel_mip/tests/test_generation.py
@@ -345,7 +345,7 @@ class TestGeneration(unittest.TestCase):
         nodes = ['a', 'b']
         graph = nx.complete_graph(nodes + ['aux0'])
         configurations = {(+1, +1): -3,
-                          (+1, -1): -6}
+                          (+1, -1): -4}
 
         bqm, gap = mip.generate_bqm(graph, configurations, nodes, min_classical_gap=0)
         self.check_bqm_graph(bqm, graph)

--- a/penaltymodel_mip/tests/test_generation.py
+++ b/penaltymodel_mip/tests/test_generation.py
@@ -357,8 +357,9 @@ class TestGeneration(unittest.TestCase):
         """
         nodes = ['a']
         graph = nx.complete_graph(nodes)
-        configurations = {(-1,): -2,
-                          (+1,): 2}
+        configurations = {(-1,): -1,
+                          (+1,): 1}
 
         bqm, gap = mip.generate_bqm(graph, configurations, nodes)
+        self.check_bqm_table(bqm, gap, configurations, nodes)
         self.check_bqm_graph(bqm, graph)

--- a/penaltymodel_mip/tests/test_generation.py
+++ b/penaltymodel_mip/tests/test_generation.py
@@ -345,7 +345,7 @@ class TestGeneration(unittest.TestCase):
         nodes = ['a', 'b']
         graph = nx.complete_graph(nodes + ['aux0'])
         configurations = {(+1, +1): -3,
-                          (+1, -1): -4}
+                          (+1, -1): -6}
 
         bqm, gap = mip.generate_bqm(graph, configurations, nodes, min_classical_gap=0)
         self.check_bqm_graph(bqm, graph)

--- a/penaltymodel_mip/tests/test_generation.py
+++ b/penaltymodel_mip/tests/test_generation.py
@@ -23,6 +23,7 @@ class TestGeneration(unittest.TestCase):
 
         highest_feasible_energy = max(table.values()) if isinstance(table, dict) else 0
 
+        # Looping though ExactSolver results and comparing with BQM
         seen_gap = float('inf')
         seen_table = set()
         for sample, energy in response.data(['sample', 'energy']):
@@ -30,6 +31,7 @@ class TestGeneration(unittest.TestCase):
 
             config = tuple(sample[v] for v in decision)
 
+            # Configurations with energies < highest feasible energy
             if energy < highest_feasible_energy + .001:
                 self.assertIn(config, table)
 
@@ -38,9 +40,11 @@ class TestGeneration(unittest.TestCase):
 
                 seen_table.add(config)
 
+            # Get smallest gap among non-table configurations
             elif config not in table:
                 seen_gap = min(seen_gap, energy - highest_feasible_energy)
 
+        # Verify that all table configurations have been accounted for
         for config in table:
             self.assertIn(config, seen_table)
 
@@ -330,18 +334,6 @@ class TestGeneration(unittest.TestCase):
         self.check_bqm_graph(bqm, graph)
 
     def test_multiple_nonzero_feasible_states_with_aux(self):
-        """
-        nodes = ['a', 'b', 'c']
-        graph = nx.complete_graph(nodes)
-        configurations = {(+1, +1, -1): -3,
-                          (+1, -1, +1): -2,
-                          (+1, -1, -1): -6,
-                          (-1, +1, -1): 0,
-                          (-1, -1, +1): -1,
-                          (-1, -1, -1): -1}
-        bqm, gap = mip.generate_bqm(graph, configurations, nodes)
-        """
-
         nodes = ['a', 'b']
         graph = nx.complete_graph(nodes + ['c'])
         configurations = {(+1, +1): -3,

--- a/penaltymodel_mip/tests/test_generation.py
+++ b/penaltymodel_mip/tests/test_generation.py
@@ -345,21 +345,18 @@ class TestGeneration(unittest.TestCase):
         nodes = ['a', 'b']
         graph = nx.complete_graph(nodes + ['aux0'])
         configurations = {(+1, +1): -3,
-                          (+1, -1): -3,
-                          (-1, -1): -3}
+                          (+1, -1): -6}
 
         bqm, gap = mip.generate_bqm(graph, configurations, nodes, min_classical_gap=0)
         self.check_bqm_graph(bqm, graph)
 
-    def test_silly(self):
+    def test_all_possible_config(self):
+        """Test when all possible configurations for the decision variable is defined
+        """
         nodes = ['a']
-        graph = nx.complete_graph(nodes + ['aux'])
-        configurations = {(-1,): -5,
-                          (+1,): 3}
-        """
-        configurations = {(-1,): -5,
-                          (+1,): 1}
-        """
+        graph = nx.complete_graph(nodes)
+        configurations = {(-1,): -2,
+                          (+1,): 2}
 
         bqm, gap = mip.generate_bqm(graph, configurations, nodes)
         self.check_bqm_graph(bqm, graph)

--- a/penaltymodel_mip/tests/test_generation.py
+++ b/penaltymodel_mip/tests/test_generation.py
@@ -345,11 +345,10 @@ class TestGeneration(unittest.TestCase):
         nodes = ['a', 'b']
         graph = nx.complete_graph(nodes + ['aux0'])
         configurations = {(+1, +1): -3,
-                          (+1, -1): -6,
-                          (-1, +1): 0,
-                          (-1, -1): -1}
+                          (+1, -1): -3,
+                          (-1, -1): -3}
 
-        bqm, gap = mip.generate_bqm(graph, configurations, nodes)
+        bqm, gap = mip.generate_bqm(graph, configurations, nodes, min_classical_gap=0)
         self.check_bqm_graph(bqm, graph)
 
     def test_silly(self):

--- a/penaltymodel_mip/tests/test_generation.py
+++ b/penaltymodel_mip/tests/test_generation.py
@@ -21,6 +21,8 @@ class TestGeneration(unittest.TestCase):
         """check that the bqm has ground states matching table"""
         response = dimod.ExactSolver().sample(bqm)
 
+        ground = min(table.values()) if isinstance(table, dict) else 0
+
         seen_gap = float('inf')
         seen_table = set()
         for sample, energy in response.data(['sample', 'energy']):
@@ -37,7 +39,7 @@ class TestGeneration(unittest.TestCase):
                 seen_table.add(config)
 
             elif config not in table:
-                seen_gap = min(seen_gap, energy)
+                seen_gap = min(seen_gap, energy - ground)
 
         for config in table:
             self.assertIn(config, seen_table)
@@ -308,4 +310,6 @@ class TestGeneration(unittest.TestCase):
         graph = nx.complete_graph(decision_variables)
         configurations = {(-1,): -1}
 
-        bqm, gap = mip.generate_bqm(graph, configurations, decision_variables)
+        bqm, gap = mip.generate_bqm(graph, configurations, decision_variables, min_classical_gap=2)
+
+        self.check_bqm_table(bqm, gap, configurations, decision_variables)

--- a/penaltymodel_mip/tests/test_generation.py
+++ b/penaltymodel_mip/tests/test_generation.py
@@ -339,7 +339,7 @@ class TestGeneration(unittest.TestCase):
         configurations = {(+1, +1): -3,
                           (+1, -1): -6}
 
-        bqm, gap = mip.generate_bqm(graph, configurations, nodes, min_classical_gap=0)
+        bqm, gap = mip.generate_bqm(graph, configurations, nodes)
 
         self.check_bqm_table(bqm, gap, configurations, nodes)
         self.check_bqm_graph(bqm, graph)

--- a/penaltymodel_mip/tests/test_generation.py
+++ b/penaltymodel_mip/tests/test_generation.py
@@ -328,3 +328,39 @@ class TestGeneration(unittest.TestCase):
 
         self.check_bqm_table(bqm, gap, configurations, nodes)
         self.check_bqm_graph(bqm, graph)
+
+    def test_multiple_nonzero_feasible_states_with_aux(self):
+        """
+        nodes = ['a', 'b', 'c']
+        graph = nx.complete_graph(nodes)
+        configurations = {(+1, +1, -1): -3,
+                          (+1, -1, +1): -2,
+                          (+1, -1, -1): -6,
+                          (-1, +1, -1): 0,
+                          (-1, -1, +1): -1,
+                          (-1, -1, -1): -1}
+        bqm, gap = mip.generate_bqm(graph, configurations, nodes)
+        """
+
+        nodes = ['a', 'b']
+        graph = nx.complete_graph(nodes + ['aux0'])
+        configurations = {(+1, +1): -3,
+                          (+1, -1): -6,
+                          (-1, +1): 0,
+                          (-1, -1): -1}
+
+        bqm, gap = mip.generate_bqm(graph, configurations, nodes)
+        self.check_bqm_graph(bqm, graph)
+
+    def test_silly(self):
+        nodes = ['a']
+        graph = nx.complete_graph(nodes + ['aux'])
+        configurations = {(-1,): -5,
+                          (+1,): 3}
+        """
+        configurations = {(-1,): -5,
+                          (+1,): 1}
+        """
+
+        bqm, gap = mip.generate_bqm(graph, configurations, nodes)
+        self.check_bqm_graph(bqm, graph)

--- a/penaltymodel_mip/tests/test_generation.py
+++ b/penaltymodel_mip/tests/test_generation.py
@@ -302,3 +302,10 @@ class TestGeneration(unittest.TestCase):
         bqm, gap = mip.generate_bqm(graph, states, nodes, min_classical_gap=smaller_min_gap)
         self.assertEqual(smaller_min_gap, gap)
         self.check_bqm_table(bqm, gap, states, nodes)
+
+    def test_nonzero_ground_state(self):
+        decision_variables = ('a',)
+        graph = nx.complete_graph(decision_variables)
+        configurations = {(-1,): -1}
+
+        bqm, gap = mip.generate_bqm(graph, configurations, decision_variables)


### PR DESCRIPTION
Please take a look.
Namely,
- When there are auxiliary variables and multiple target energy levels, `generate_bqm(..)` will result to an ImpossiblePenaltyModel error.  See unit test `test_multiple_nonzero_feasible_states_with_aux(..)`. Oddly enough, the unit test would pass if the target energy levels were all the same value.
- A bigger problem that probably involves the master branch: if you specify all possible spin configurations, the bqm will not generate. This is regardless of whether an auxiliary variable is used. See unit test `test_all_possible_config(..)`
