### PR TITLE
Fix/update package version

### DIFF
--- a/penaltymodel_cache/penaltymodel/cache/package_info.py
+++ b/penaltymodel_cache/penaltymodel/cache/package_info.py
@@ -1,4 +1,4 @@
-__version__ = '0.3.3'
+__version__ = '0.3.4'
 __author__ = 'D-Wave Systems Inc.'
 __authoremail__ = 'acondello@dwavesys.com'
 __description__ = 'A local cache for penalty models.'

--- a/penaltymodel_core/penaltymodel/core/package_info.py
+++ b/penaltymodel_core/penaltymodel/core/package_info.py
@@ -1,4 +1,4 @@
-__version__ = '0.16.0'
+__version__ = '0.16.2'
 __author__ = 'D-Wave Systems Inc.'
 __authoremail__ = 'acondello@dwavesys.com'
 __description__ = 'Utilities and interfaces for using penalty models.'


### PR DESCRIPTION
* Bump up penaltymodel-cache because core has been updated (a few weeks back). I should have also bumped up cache at that time too. Better late than never.
* Note: 0.16.0 is the updated core version from a few weeks back; this change requires cache to support `min_classical_gap` as a key for cached penaltymodels. Hence, the cache install requirement contains `penaltymodel>=0.16.0,<0.17.0` (this install requirements bump DID happen a few weeks back).
* Had released `penaltymodel-core 0.16.1`, but forgot to change the version in `package_info.py`. Hence, it's necessary to do another release with matching version numbers, namely 0.16.2