### PR TITLE
Change cache version

### DIFF
--- a/penaltymodel_cache/penaltymodel/cache/package_info.py
+++ b/penaltymodel_cache/penaltymodel/cache/package_info.py
@@ -1,4 +1,4 @@
-__version__ = '0.3.4'
+__version__ = '0.4.0'
 __author__ = 'D-Wave Systems Inc.'
 __authoremail__ = 'acondello@dwavesys.com'
 __description__ = 'A local cache for penalty models.'


### PR DESCRIPTION
* Cache now uses penaltymodel 0.16.0. This is causing requirement conflicts with code that uses older versions of cache. Hence the need to do a major bump to prevent requirement conflicts.