### PR TITLE
Fix/102 penaltymodel lp fast fail solution

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,11 +121,6 @@ jobs:
   #   docker:
   #     - image: circleci/python:3.4-jessie
 
-  test-2.7:
-    <<: *full-test-template
-    docker:
-      - image: circleci/python:2.7-jessie
-
   test-osx-3.7: &osx-tests-template
     macos:
       xcode: "10.1.0"
@@ -215,12 +210,6 @@ jobs:
   #   environment:
   #     PYTHON: 3.4.8
   #     HOMEBREW_NO_AUTO_UPDATE: 1
-
-  test-osx-2.7:
-    <<: *osx-tests-template
-    environment:
-      PYTHON: 2.7.15
-      HOMEBREW_NO_AUTO_UPDATE: 1
 
   deploy-core:
     docker:
@@ -408,12 +397,10 @@ workflows:
       - test-3.6
       - test-3.5
       # - test-3.4
-      - test-2.7
       - test-osx-3.7
       - test-osx-3.6
       - test-osx-3.5
       # - test-osx-3.4
-      - test-osx-2.7
       - deploy-core:
           filters:
             tags:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,6 @@ environment:
 
     # https://www.appveyor.com/docs/build-environment/#python
 
-    - PYTHON: "C:\\Python27-x64"
     # - PYTHON: "C:\\Python34-x64"
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36-x64"

--- a/penaltymodel_lp/penaltymodel/lp/generation.py
+++ b/penaltymodel_lp/penaltymodel/lp/generation.py
@@ -163,7 +163,12 @@ def generate_bqm(graph, table, decision_variables,
 
     # Returns a Scipy OptimizeResult
     # Note: if linear program encounters an ill conditioned matrix or non-full-row-rank matrix,
-    #   rather than let it continue, just fail and allow the next penaltymodel to make an attempt
+    #   rather than let it continue, just fail and allow the next penaltymodel to make an attempt.
+    #   This is just a quick fix as I worry that the warnings could indicate an unreliable
+    #   solution. Note that non-full-row-rank matrix is probably okay, but I feel more comfortable
+    #   failing early and getting a reliable solution from another penaltymodel than from
+    #   simply suppressing the non-full-row-rank matrix warning.
+    # TODO: address warnings by preconditioning the matrix and factorizing the matrix
     with warnings.catch_warnings():
         warnings.filterwarnings("error")
         try:

--- a/penaltymodel_lp/test_generation.py
+++ b/penaltymodel_lp/test_generation.py
@@ -191,6 +191,11 @@ class TestPenaltyModelLinearProgramming(unittest.TestCase):
         with self.assertRaises(ValueError):
             lp.generate_bqm(nx.complete_graph(nodes), xor_gate_values, nodes)
 
+    def test_ill_conditioned_matrix(self):
+
+        with self.assertRaises(ValueError):
+            pass
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #102

If the the linear program throws a warning (ex. matrix is ill-conditioned), just fail and let MIP deal with the constraint. Note that I could apply LU-factorization (to deal with the not-full-row-rank issue) and MAYBE do regularization on the matrix (to hopefully help with the ill-conditioned matrix issue), but I think that may be over-kill for what `penaltymodel-lp` was meant to do (that being, it deals with the easy to solve constraints). 