### PR TITLE
Fix Theta __init__ to use super

### DIFF
--- a/penaltymodel_maxgap/penaltymodel/maxgap/theta.py
+++ b/penaltymodel_maxgap/penaltymodel/maxgap/theta.py
@@ -40,13 +40,13 @@ def limitReal(x, max_denominator=1000000):
 
 
 class Theta(dimod.BinaryQuadraticModel):
-    def __init__(self, linear, quadratic, offset, vartype):
+    def __init__(self, *args, **kwargs):
         """Theta is a BQM where the biases are pysmt Symbols.
 
         Theta is normally constructed using :meth:`.Theta.from_graph`.
 
         """
-        dimod.BinaryQuadraticModel.__init__(self, linear, quadratic, offset, vartype)
+        super(Theta, self).__init__(*args, **kwargs)
 
         # add additional assertions tab
         self.assertions = set()


### PR DESCRIPTION
Not actually required to support dimod 0.9.0 because of https://github.com/dwavesystems/dimod/pull/616/commits/e770917e82297133ff211f7325fc1d8ad1eaeca5 and https://github.com/dwavesystems/dimod/pull/616/commits/e6e766d18b0bab54ba9d7c6197346fe68a85e9c2 providing backwards compatibility. But might as well fix this for the future