### PR TITLE
Fix/114 cache fails for 1 variable pms

### DIFF
--- a/penaltymodel_cache/penaltymodel/cache/database_manager.py
+++ b/penaltymodel_cache/penaltymodel/cache/database_manager.py
@@ -290,13 +290,13 @@ def insert_ising_model(cur, nodelist, edgelist, linear, quadratic, offset, encod
     if 'offset' not in encoded_data:
         encoded_data['offset'] = offset
     if 'max_quadratic_bias' not in encoded_data:
-        encoded_data['max_quadratic_bias'] = max(itervalues(quadratic))
+        encoded_data['max_quadratic_bias'] = max(itervalues(quadratic), default=None)
     if 'min_quadratic_bias' not in encoded_data:
-        encoded_data['min_quadratic_bias'] = min(itervalues(quadratic))
+        encoded_data['min_quadratic_bias'] = min(itervalues(quadratic), default=None)
     if 'max_linear_bias' not in encoded_data:
-        encoded_data['max_linear_bias'] = max(itervalues(linear))
+        encoded_data['max_linear_bias'] = max(itervalues(linear), default=None)
     if 'min_linear_bias' not in encoded_data:
-        encoded_data['min_linear_bias'] = min(itervalues(linear))
+        encoded_data['min_linear_bias'] = min(itervalues(linear), default=None)
 
     insert = \
         """

--- a/penaltymodel_cache/penaltymodel/cache/database_manager.py
+++ b/penaltymodel_cache/penaltymodel/cache/database_manager.py
@@ -290,13 +290,13 @@ def insert_ising_model(cur, nodelist, edgelist, linear, quadratic, offset, encod
     if 'offset' not in encoded_data:
         encoded_data['offset'] = offset
     if 'max_quadratic_bias' not in encoded_data:
-        encoded_data['max_quadratic_bias'] = max(itervalues(quadratic), default=None)
+        encoded_data['max_quadratic_bias'] = max(itervalues(quadratic), default=0)
     if 'min_quadratic_bias' not in encoded_data:
-        encoded_data['min_quadratic_bias'] = min(itervalues(quadratic), default=None)
+        encoded_data['min_quadratic_bias'] = min(itervalues(quadratic), default=0)
     if 'max_linear_bias' not in encoded_data:
-        encoded_data['max_linear_bias'] = max(itervalues(linear), default=None)
+        encoded_data['max_linear_bias'] = max(itervalues(linear), default=0)
     if 'min_linear_bias' not in encoded_data:
-        encoded_data['min_linear_bias'] = min(itervalues(linear), default=None)
+        encoded_data['min_linear_bias'] = min(itervalues(linear), default=0)
 
     insert = \
         """

--- a/penaltymodel_cache/requirements.txt
+++ b/penaltymodel_cache/requirements.txt
@@ -1,3 +1,3 @@
 homebase==1.0.0
 six==1.11.0
-dimod==0.8.18
+dimod==0.9.0

--- a/penaltymodel_cache/tests/test_interface.py
+++ b/penaltymodel_cache/tests/test_interface.py
@@ -198,3 +198,20 @@ class TestInterfaceFunctions(unittest.TestCase):
             self.assertNotEqual(ret_pmodel, pmodel)
         except:
             pass
+
+    def test_one_variable_insert_retrieve(self):
+        dbfile = self.database
+
+        # generate one variable model (i.e. no quadratic terms)
+        spec = pm.Specification(graph=nx.complete_graph(1),
+                                decision_variables=[0],
+                                feasible_configurations=[(-1,)],
+                                min_classical_gap=2, vartype='SPIN')
+        pmodel = pm.get_penalty_model(spec)
+
+        # insert model into cache
+        pmc.cache_penalty_model(pmodel, database=dbfile)
+
+        # retrieve model back from cache
+        retrieved_model = pmc.get_penalty_model(spec, database=dbfile)
+        self.assertEqual(pmodel, retrieved_model)

--- a/penaltymodel_cache/tests/test_interface.py
+++ b/penaltymodel_cache/tests/test_interface.py
@@ -200,6 +200,9 @@ class TestInterfaceFunctions(unittest.TestCase):
             pass
 
     def test_one_variable_insert_retrieve(self):
+        """Test case when there is no quadratic contribution (i.e. cache will
+        receive an empty value for the quadratic contribution)
+        """
         dbfile = self.database
 
         # generate one variable model (i.e. no quadratic terms)
@@ -215,3 +218,12 @@ class TestInterfaceFunctions(unittest.TestCase):
         # retrieve model back from cache
         retrieved_model = pmc.get_penalty_model(spec, database=dbfile)
         self.assertEqual(pmodel, retrieved_model)
+
+    def test_empty_linear_insert_retrieve(self):
+        """Test case when there is no linear contribution (i.e. cache will
+        receive an empty value for the linear contribution)
+        """
+        dbfile = self.database
+
+        # make a model that does not contain any linear terms
+        pass

--- a/penaltymodel_cache/tests/test_interface.py
+++ b/penaltymodel_cache/tests/test_interface.py
@@ -219,11 +219,27 @@ class TestInterfaceFunctions(unittest.TestCase):
         retrieved_model = pmc.get_penalty_model(spec, database=dbfile)
         self.assertEqual(pmodel, retrieved_model)
 
-    def test_empty_linear_insert_retrieve(self):
-        """Test case when there is no linear contribution (i.e. cache will
-        receive an empty value for the linear contribution)
-        """
+    def test_no_linear_bias_insert_retrieve(self):
+        """Test case when there is no linear bias"""
         dbfile = self.database
 
-        # make a model that does not contain any linear terms
-        pass
+        # define specifications
+        spec = pm.Specification(graph=nx.complete_graph(2),
+                                decision_variables=[0, 1],
+                                feasible_configurations=[(-1, +1), (+1, -1)],
+                                min_classical_gap=2, vartype='SPIN')
+
+        # make a model
+        # note: model must satisfy specifications and not have a nonzero linear bias
+        linear = {}
+        quadratic = {(0, 1): 1}
+        offset = 0.0
+        model = dimod.BinaryQuadraticModel(linear, quadratic, offset, vartype=dimod.SPIN)
+        pmodel = pm.PenaltyModel.from_specification(spec, model, 2, -1)
+
+        # insert model into cache
+        pmc.cache_penalty_model(pmodel, database=dbfile)
+
+        # retrieve model back from cache
+        retrieved_model = pmc.get_penalty_model(spec, database=dbfile)
+        self.assertEqual(pmodel, retrieved_model)

--- a/penaltymodel_core/requirements.txt
+++ b/penaltymodel_core/requirements.txt
@@ -1,3 +1,3 @@
-dimod==0.8.18
+dimod==0.9.0
 six==1.11.0
 networkx==2.0

--- a/penaltymodel_lp/requirements.txt
+++ b/penaltymodel_lp/requirements.txt
@@ -1,4 +1,4 @@
-dimod==0.8.18
+dimod==0.9.0
 dwavebinarycsp==0.0.10
 numpy==1.18.1
 scipy==1.4.1

--- a/penaltymodel_maxgap/requirements.txt
+++ b/penaltymodel_maxgap/requirements.txt
@@ -1,3 +1,3 @@
 dwave_networkx==0.6.0
 pysmt==0.8.0
-dimod==0.8.18
+dimod==0.9.0

--- a/penaltymodel_mip/requirements.txt
+++ b/penaltymodel_mip/requirements.txt
@@ -1,3 +1,3 @@
-dimod==0.8.18
+dimod==0.9.0
 networkx==2.0
 ortools>=6.6.4659,<8.0.0; platform_machine != "x86"


### PR DESCRIPTION
Closes #114 

- bump up penaltymodel requirements to use latest dimod
- fix cache failing for 1 variable penaltymodels. The issue was that the quadratic terms were empty for the 1 variable penaltymodel case, hence when the cache was trying to take the min/max of the quadratic terms, it just completely failed. Solution was to give some default values.