### PR TITLE
Fix interface test failures

### DIFF
--- a/penaltymodel_cache/penaltymodel/cache/__init__.py
+++ b/penaltymodel_cache/penaltymodel/cache/__init__.py
@@ -12,3 +12,5 @@ from penaltymodel.cache.interface import *
 import penaltymodel.cache.interface
 
 from penaltymodel.cache.package_info import *
+
+from penaltymodel.cache.utils import *

--- a/penaltymodel_cache/penaltymodel/cache/utils.py
+++ b/penaltymodel_cache/penaltymodel/cache/utils.py
@@ -29,3 +29,4 @@ def isolated_cache(f):
                 f(obj)
 
     return _isolated_cache
+    

--- a/penaltymodel_cache/penaltymodel/cache/utils.py
+++ b/penaltymodel_cache/penaltymodel/cache/utils.py
@@ -1,0 +1,31 @@
+# Copyright 2020 D-Wave Systems Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+# ================================================================================================
+from unittest import mock
+import tempfile
+import os.path as path
+from functools import wraps
+
+def isolated_cache(f):
+    """Method decorator used to isolate the method's penaltymodel cache."""
+    @wraps(f)
+    def _isolated_cache(obj):
+        with tempfile.TemporaryDirectory() as tmpdir:         
+            filename = path.join(tmpdir, "tmp_db_file")
+
+            with mock.patch("penaltymodel.cache.database_manager.cache_file", lambda: filename):
+                f(obj)
+
+    return _isolated_cache

--- a/tests/test_int_penaltymodel_ecosystem.py
+++ b/tests/test_int_penaltymodel_ecosystem.py
@@ -1,4 +1,6 @@
 import unittest
+from unittest import mock
+import tempfile
 
 import networkx as nx
 
@@ -8,31 +10,33 @@ import penaltymodel.core as pm
 import penaltymodel.cache as pmc
 import penaltymodel.maxgap as maxgap
 
-
 class TestInterfaceWithCache(unittest.TestCase):
     def test_retrieval(self):
-        # put some stuff in the database
+        tmp_db_file = tempfile.NamedTemporaryFile().name
 
-        spec = pm.Specification(nx.path_graph(2), (0, 1), {(-1, -1), (1, 1)}, vartype=pm.SPIN)
-        model = dimod.BinaryQuadraticModel({0: 0, 1: 0}, {(0, 1): -1}, 0.0, vartype=pm.SPIN)
-        widget = pm.PenaltyModel.from_specification(spec, model, 2, -1)
+        with mock.patch("penaltymodel.cache.database_manager.cache_file", lambda: tmp_db_file):
+            # put some stuff in the database
+            spec = pm.Specification(nx.path_graph(2), (0, 1), {(-1, -1), (1, 1)}, vartype=pm.SPIN)
+            model = dimod.BinaryQuadraticModel({0: 0, 1: 0}, {(0, 1): -1}, 0.0, vartype=pm.SPIN)
+            widget = pm.PenaltyModel.from_specification(spec, model, 2, -1)
 
-        for cache in pm.iter_caches():
-            cache(widget)
+            for cache in pm.iter_caches():
+                cache(widget)
 
-        # now try to get it back
-        new_widget = pm.get_penalty_model(spec)
+            # now try to get it back
+            new_widget = pm.get_penalty_model(spec)
 
-        self.assertEqual(widget, new_widget)
-
+            self.assertEqual(widget, new_widget)
 
 class TestInterfaceWithMaxGap(unittest.TestCase):
     def test_retrieval(self):
+        tmp_db_file = tempfile.NamedTemporaryFile().name
 
-        eq = {(-1, -1), (1, 1)}
+        with mock.patch("penaltymodel.cache.database_manager.cache_file", lambda: tmp_db_file):
+            eq = {(-1, -1), (1, 1)}
 
-        spec = pm.Specification(nx.path_graph(2), (0, 1), eq, vartype=pm.SPIN)
-        widget = pm.get_penalty_model(spec)
+            spec = pm.Specification(nx.path_graph(2), (0, 1), eq, vartype=pm.SPIN)
+            widget = pm.get_penalty_model(spec)
 
-        self.assertEqual(widget.model.linear, {0: 0, 1: 0})
-        self.assertEqual(widget.model.quadratic, {(0, 1): -1})
+            self.assertEqual(widget.model.linear, {0: 0, 1: 0})
+            self.assertEqual(widget.model.quadratic, {(0, 1): -1})

--- a/tests/test_int_penaltymodel_ecosystem.py
+++ b/tests/test_int_penaltymodel_ecosystem.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest import mock
 import tempfile
+import os.path as path
 
 import networkx as nx
 
@@ -10,21 +11,22 @@ import penaltymodel.core as pm
 
 class TestInterfaceWithCache(unittest.TestCase):
     def test_retrieval(self):
-        tmp_db_file = tempfile.NamedTemporaryFile().name
+        with tempfile.TemporaryDirectory() as tmpdir:         
+            filename = path.join(tmpdir, 'tmp_db_file')
 
-        with mock.patch("penaltymodel.cache.database_manager.cache_file", lambda: tmp_db_file):
-            # put some stuff in the database
-            spec = pm.Specification(nx.path_graph(2), (0, 1), {(-1, -1), (1, 1)}, vartype=pm.SPIN)
-            model = dimod.BinaryQuadraticModel({0: 0, 1: 0}, {(0, 1): -1}, 0.0, vartype=pm.SPIN)
-            widget = pm.PenaltyModel.from_specification(spec, model, 2, -1)
+            with mock.patch("penaltymodel.cache.database_manager.cache_file", lambda: filename):
+                # put some stuff in the database
+                spec = pm.Specification(nx.path_graph(2), (0, 1), {(-1, -1), (1, 1)}, vartype=pm.SPIN)
+                model = dimod.BinaryQuadraticModel({0: 0, 1: 0}, {(0, 1): -1}, 0.0, vartype=pm.SPIN)
+                widget = pm.PenaltyModel.from_specification(spec, model, 2, -1)
 
-            for cache in pm.iter_caches():
-                cache(widget)
+                for cache in pm.iter_caches():
+                    cache(widget)
 
-            # now try to get it back
-            new_widget = pm.get_penalty_model(spec)
+                # now try to get it back
+                new_widget = pm.get_penalty_model(spec)
 
-            self.assertEqual(widget, new_widget)
+                self.assertEqual(widget, new_widget)
 
 class TestInterfaceWithLP(unittest.TestCase):
     def assert_dict_almost_equal(self, dict0, dict1):
@@ -32,13 +34,14 @@ class TestInterfaceWithLP(unittest.TestCase):
             self.assertAlmostEqual(dict0[key], dict1[key])
 
     def test_retrieval(self):
-        tmp_db_file = tempfile.NamedTemporaryFile().name
+        with tempfile.TemporaryDirectory() as tmpdir:         
+            filename = path.join(tmpdir, 'tmp_db_file')
 
-        with mock.patch("penaltymodel.cache.database_manager.cache_file", lambda: tmp_db_file):
-            eq = {(-1, -1), (1, 1)}
+            with mock.patch("penaltymodel.cache.database_manager.cache_file", lambda: filename):
+                eq = {(-1, -1), (1, 1)}
 
-            spec = pm.Specification(nx.path_graph(2), (0, 1), eq, vartype=pm.SPIN)
-            widget = pm.get_penalty_model(spec)
+                spec = pm.Specification(nx.path_graph(2), (0, 1), eq, vartype=pm.SPIN)
+                widget = pm.get_penalty_model(spec)
 
-            self.assert_dict_almost_equal(widget.model.linear, {0: 0, 1: 0})
-            self.assert_dict_almost_equal(widget.model.quadratic, {(0, 1): -1})
+                self.assert_dict_almost_equal(widget.model.linear, {0: 0, 1: 0})
+                self.assert_dict_almost_equal(widget.model.quadratic, {(0, 1): -1})

--- a/tests/test_int_penaltymodel_ecosystem.py
+++ b/tests/test_int_penaltymodel_ecosystem.py
@@ -30,6 +30,7 @@ class TestInterfaceWithCache(unittest.TestCase):
 
 class TestInterfaceWithLP(unittest.TestCase):
     def assert_dict_almost_equal(self, dict0, dict1):
+        self.assertEqual(len(dict0), len(dict1))
         for key in dict0:
             self.assertAlmostEqual(dict0[key], dict1[key])
 

--- a/tests/test_int_penaltymodel_ecosystem.py
+++ b/tests/test_int_penaltymodel_ecosystem.py
@@ -9,24 +9,33 @@ import dimod
 
 import penaltymodel.core as pm
 
-class TestInterfaceWithCache(unittest.TestCase):
-    def test_retrieval(self):
+def isolated_cache(f):
+    """Method decorator used to isolate the method's penaltymodel cache."""
+    def _isolated_cache(obj):
         with tempfile.TemporaryDirectory() as tmpdir:         
-            filename = path.join(tmpdir, 'tmp_db_file')
+            filename = path.join(tmpdir, "tmp_db_file")
 
             with mock.patch("penaltymodel.cache.database_manager.cache_file", lambda: filename):
-                # put some stuff in the database
-                spec = pm.Specification(nx.path_graph(2), (0, 1), {(-1, -1), (1, 1)}, vartype=pm.SPIN)
-                model = dimod.BinaryQuadraticModel({0: 0, 1: 0}, {(0, 1): -1}, 0.0, vartype=pm.SPIN)
-                widget = pm.PenaltyModel.from_specification(spec, model, 2, -1)
+                f(obj)
 
-                for cache in pm.iter_caches():
-                    cache(widget)
+    return _isolated_cache
 
-                # now try to get it back
-                new_widget = pm.get_penalty_model(spec)
+class TestInterfaceWithCache(unittest.TestCase):
+    @isolated_cache
+    def test_retrieval(self):
+        # put some stuff in the database
 
-                self.assertEqual(widget, new_widget)
+        spec = pm.Specification(nx.path_graph(2), (0, 1), {(-1, -1), (1, 1)}, vartype=pm.SPIN)
+        model = dimod.BinaryQuadraticModel({0: 0, 1: 0}, {(0, 1): -1}, 0.0, vartype=pm.SPIN)
+        widget = pm.PenaltyModel.from_specification(spec, model, 2, -1)
+
+        for cache in pm.iter_caches():
+            cache(widget)
+
+        # now try to get it back
+        new_widget = pm.get_penalty_model(spec)
+
+        self.assertEqual(widget, new_widget)
 
 class TestInterfaceWithLP(unittest.TestCase):
     def assert_dict_almost_equal(self, dict0, dict1):
@@ -34,15 +43,12 @@ class TestInterfaceWithLP(unittest.TestCase):
         for key in dict0:
             self.assertAlmostEqual(dict0[key], dict1[key])
 
+    @isolated_cache
     def test_retrieval(self):
-        with tempfile.TemporaryDirectory() as tmpdir:         
-            filename = path.join(tmpdir, 'tmp_db_file')
+        eq = {(-1, -1), (1, 1)}
 
-            with mock.patch("penaltymodel.cache.database_manager.cache_file", lambda: filename):
-                eq = {(-1, -1), (1, 1)}
+        spec = pm.Specification(nx.path_graph(2), (0, 1), eq, vartype=pm.SPIN)
+        widget = pm.get_penalty_model(spec)
 
-                spec = pm.Specification(nx.path_graph(2), (0, 1), eq, vartype=pm.SPIN)
-                widget = pm.get_penalty_model(spec)
-
-                self.assert_dict_almost_equal(widget.model.linear, {0: 0, 1: 0})
-                self.assert_dict_almost_equal(widget.model.quadratic, {(0, 1): -1})
+        self.assert_dict_almost_equal(widget.model.linear, {0: 0, 1: 0})
+        self.assert_dict_almost_equal(widget.model.quadratic, {(0, 1): -1})

--- a/tests/test_int_penaltymodel_ecosystem.py
+++ b/tests/test_int_penaltymodel_ecosystem.py
@@ -7,8 +7,6 @@ import networkx as nx
 import dimod
 
 import penaltymodel.core as pm
-import penaltymodel.cache as pmc
-import penaltymodel.maxgap as maxgap
 
 class TestInterfaceWithCache(unittest.TestCase):
     def test_retrieval(self):
@@ -28,7 +26,11 @@ class TestInterfaceWithCache(unittest.TestCase):
 
             self.assertEqual(widget, new_widget)
 
-class TestInterfaceWithMaxGap(unittest.TestCase):
+class TestInterfaceWithLP(unittest.TestCase):
+    def assert_dict_almost_equal(self, dict0, dict1):
+        for key in dict0:
+            self.assertAlmostEqual(dict0[key], dict1[key])
+
     def test_retrieval(self):
         tmp_db_file = tempfile.NamedTemporaryFile().name
 
@@ -38,5 +40,5 @@ class TestInterfaceWithMaxGap(unittest.TestCase):
             spec = pm.Specification(nx.path_graph(2), (0, 1), eq, vartype=pm.SPIN)
             widget = pm.get_penalty_model(spec)
 
-            self.assertEqual(widget.model.linear, {0: 0, 1: 0})
-            self.assertEqual(widget.model.quadratic, {(0, 1): -1})
+            self.assert_dict_almost_equal(widget.model.linear, {0: 0, 1: 0})
+            self.assert_dict_almost_equal(widget.model.quadratic, {(0, 1): -1})

--- a/tests/test_int_penaltymodel_ecosystem.py
+++ b/tests/test_int_penaltymodel_ecosystem.py
@@ -28,6 +28,7 @@ class TestInterfaceWithLP(unittest.TestCase):
     def assert_dict_almost_equal(self, dict0, dict1):
         self.assertEqual(len(dict0), len(dict1))
         for key in dict0:
+            self.assertIn(key, dict1)
             self.assertAlmostEqual(dict0[key], dict1[key])
 
     @isolated_cache

--- a/tests/test_int_penaltymodel_ecosystem.py
+++ b/tests/test_int_penaltymodel_ecosystem.py
@@ -1,24 +1,11 @@
 import unittest
-from unittest import mock
-import tempfile
-import os.path as path
 
 import networkx as nx
 
 import dimod
 
 import penaltymodel.core as pm
-
-def isolated_cache(f):
-    """Method decorator used to isolate the method's penaltymodel cache."""
-    def _isolated_cache(obj):
-        with tempfile.TemporaryDirectory() as tmpdir:         
-            filename = path.join(tmpdir, "tmp_db_file")
-
-            with mock.patch("penaltymodel.cache.database_manager.cache_file", lambda: filename):
-                f(obj)
-
-    return _isolated_cache
+from penaltymodel.cache.utils import isolated_cache
 
 class TestInterfaceWithCache(unittest.TestCase):
     @isolated_cache


### PR DESCRIPTION
- Isolate cache for each interface test
- Account for LP rounding errors 
- This should fix test failures that occur when the tests are ran on the sdk integration tests