### PR TITLE
Import Mapping from collections.abc

### DIFF
--- a/penaltymodel_mip/penaltymodel/mip/generation.py
+++ b/penaltymodel_mip/penaltymodel/mip/generation.py
@@ -15,7 +15,8 @@
 import itertools
 import random
 
-from collections import Mapping, defaultdict
+from collections import defaultdict
+from collections.abc import Mapping
 
 import dimod
 import networkx as nx


### PR DESCRIPTION
To eliminate deprecation warning.  Online docs (https://docs.python.org/3.8/library/collections.html) indicate that importing the abstract base classes directly from collections will be removed in version 3.10 (and has been deprecated since 3.3).

Note: I have not tested the change within the penaltymodel package (I receive a `ModuleNotFoundError` when running `python -m unittest` on a clean version), but isolated testing of the import statements does confirm that it should eliminate the deprecation warning.