### PR TITLE
Restore import of exceptions from penaltymodel.core

### DIFF
--- a/penaltymodel/core/__init__.py
+++ b/penaltymodel/core/__init__.py
@@ -1,6 +1,21 @@
+# Copyright 2022 D-Wave Systems Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
 from penaltymodel.core.classes import *
 import penaltymodel.core.classes
 
+from penaltymodel.core.exceptions import *
 import penaltymodel.core.exceptions
 
 from penaltymodel.core.interface import *

--- a/releasenotes/notes/fix-penaltymodel-core-21d1800fc17f03f5.yaml
+++ b/releasenotes/notes/fix-penaltymodel-core-21d1800fc17f03f5.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Restore ability to import exceptions from the ``penaltymodel.core`` namespace.
+    This was accidentally removed in 1.0.0.

--- a/tests/test_interface_deprecated.py
+++ b/tests/test_interface_deprecated.py
@@ -68,3 +68,8 @@ class TestIterFactories(unittest.TestCase):
             factory, = iter_factories()
 
         self.assertIs(factory, get_penalty_model)
+
+
+class TestCoreNamespace(unittest.TestCase):
+    def test_import(self):
+        from penaltymodel.core import ImpossiblePenaltyModel


### PR DESCRIPTION
Allows for slightly more backwards compatibility