### PR TITLE
Fix unittests for SciPy~=1.9.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,14 +185,14 @@ workflows:
             parameters:
               python-version: [3.7.9, 3.8.6, 3.9.0, 3.10.0]
               pip-constraints:
-                # test the min and max (as of April 2022) version ranges
+                # test the min and max (as of July 2022) version ranges
                 - dimod==0.10.9 scipy==1.6.0 numpy==1.20.0
-                - dimod==0.11.0rc1 scipy~=1.8.0 numpy~=1.22.0
+                - dimod~=0.11.0 scipy~=1.9.0 numpy~=1.23.0
             exclude:
                 - python-version: 3.10.0
                   pip-constraints: dimod==0.10.9 scipy==1.6.0 numpy==1.20.0
                 - python-version: 3.7.9
-                  pip-constraints: dimod==0.11.0rc1 scipy~=1.8.0 numpy~=1.22.0
+                  pip-constraints: dimod~=0.11.0 scipy~=1.9.0 numpy~=1.23.0
       - test-macos:
           name: test-macos-<< matrix.python-version >>
           matrix:

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -143,11 +143,11 @@ class TestGenerate(unittest.TestCase):
 
         # check energy ranges
         for v, bias in bqm.linear.items():
-            self.assertGreaterEqual(bias, min_lin)
-            self.assertLessEqual(bias, max_lin)
+            self.assertGreaterEqual(round(bias, 9), min_lin)
+            self.assertLessEqual(round(bias, 9), max_lin)
 
         for (u, v), bias in bqm.quadratic.items():
-            self.assertGreaterEqual(bias, min_quad)
+            self.assertGreaterEqual(round(bias, 9), min_quad)
             self.assertLessEqual(round(bias, 9), max_quad)
 
         self.assertAlmostEqual(best_gap, gap)


### PR DESCRIPTION
In SciPy~=1.9.0 the bounds might be slightly exceeded so we loosen the unittests to allow for that.

We could do a more invasive change where we round, but IMO it's better to just propagate SciPy's behavior and let them fix/adjust it.