### PR TITLE
Fix duplicate ``tbl_andgate`` label warning

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,6 @@ Next, we need to determine the feasible configurations that we wish to target (b
 Below is the truth table representing an AND clause.
 
 .. table:: AND Gate
-   :name: tbl_ANDgate
 
    ====================  ====================  ==================
    ``x_1``               ``x_2``               ``z``


### PR DESCRIPTION
Part of [sdk](https://github.com/dwavesystems/dwave-ocean-sdk/pull/300) cleanup of build warnings. 
This table is in both the README and is brought into the [SDK index page](https://docs.ocean.dwavesys.com/en/stable/docs_penalty/sdk_index.html) for this repo, causing a build warning, ``docs_penalty/README.rst:: WARNING: duplicate label tbl_andgate, other instance in /home/circleci/repo/docs/docs_penalty/index.rst``. The table is not referenced from elsewhere and doesn't need the label. 